### PR TITLE
 Split snapshots, better ld_preload detection, fix FP

### DIFF
--- a/Endpoints/packs/windows-attacks.conf
+++ b/Endpoints/packs/windows-attacks.conf
@@ -2,7 +2,7 @@
   "platform": "windows",
   "queries": {
     "StickyKeys_File_Replace_Backdoor": {
-      "query": "SELECT * FROM hash WHERE (path='c:\\windows\\system32\\osk.exe' OR path='c:\\windows\\system32\\sethc.exe' OR path='c:\\windows\\system32\\narrator.exe' OR path='c:\\windows\\system32\\magnify.exe' OR path='c:\\windows\\system32\\displayswitch.exe') AND sha256 IN (SELECT sha256 FROM hash WHERE path='c:\\windows\\system32\\cmd.exe' OR path='c:\\windows\\system32\\WindowsPowerShell\\v1.0\\powershell.exe' OR path='c:\\windows\\system32\\explorer.exe');",
+      "query": "SELECT * FROM hash WHERE (path='c:\\windows\\system32\\osk.exe' OR path='c:\\windows\\system32\\sethc.exe' OR path='c:\\windows\\system32\\narrator.exe' OR path='c:\\windows\\system32\\magnify.exe' OR path='c:\\windows\\system32\\displayswitch.exe') AND sha256 IN (SELECT sha256 FROM hash WHERE path='c:\\windows\\system32\\cmd.exe' OR path='c:\\windows\\system32\\WindowsPowerShell\\v1.0\\powershell.exe' OR path='c:\\windows\\system32\\explorer.exe') AND sha256!='e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855';",
       "interval": 3600,
       "description": "Checks the hashes of accessibility tools to ensure they don't match the hashes of cmd.exe, powershell.exe, or explorer.exe. More info: https://github.com/TrullJ/sticky-keys-scanner/blob/master/TestFor-StickyKey.ps1"
     },

--- a/Servers/Linux/osquery.conf
+++ b/Servers/Linux/osquery.conf
@@ -1,5 +1,6 @@
 {
   "options": {
+    "logger_snapshot_event_type": "true",
     "schedule_splay_percent": 10
   },
   "platform": "linux",
@@ -100,9 +101,15 @@
       "description" : "Retrieves the list of the latest logins with PID, username and timestamp."
     },
     "ld_preload": {
-      "query" : "SELECT * FROM process_envs WHERE key = 'LD_PRELOAD';",
+      "query" : "SELECT process_envs.pid, process_envs.key, process_envs.value, processes.name, processes.path, processes.cmdline, processes.cwd FROM process_envs join processes USING (pid) WHERE key = 'LD_PRELOAD';",
       "interval" : 60,
       "description" : "Any processes that run with an LD_PRELOAD environment variable"
+    },
+    "ld_so_preload_exists": {
+      "query" : "SELECT * FROM file WHERE path='/etc/ld.so.preload';",
+      "interval" : 3600,
+      "version" : "1.4.5",
+      "description" : "Generates an event if ld.so.preload is present - used by rootkits such as Jynx"
     },
     "memory_info": {
       "query": "SELECT * FROM memory_info;",
@@ -214,7 +221,6 @@
     "configuration": [
       "/etc/passwd",
       "/etc/shadow",
-      "/etc/ld.so.preload",
       "/etc/ld.so.conf.d/%%",
       "/etc/pam.d/%%",
       "/etc/resolv.conf",

--- a/Servers/Linux/osquery.conf
+++ b/Servers/Linux/osquery.conf
@@ -108,7 +108,6 @@
     "ld_so_preload_exists": {
       "query" : "SELECT * FROM file WHERE path='/etc/ld.so.preload';",
       "interval" : 3600,
-      "version" : "1.4.5",
       "description" : "Generates an event if ld.so.preload is present - used by rootkits such as Jynx"
     },
     "memory_info": {


### PR DESCRIPTION
• Filters out the SHA256 hash for an empty file (e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855) which can cause false positives in `StickyKeys_File_Replace_Backdoor`
• Enables snapshot splitting (only supported on v2.10+)
• Improved the ld_preload query by adding process context
• Removed ld.so.preload from file_events. If the file is not there when osqueryd starts, osquery will never see it due to limitations of inotify. It's better to explicitly check for it using the file table.