### PR TITLE
Filter blank paths from windows-attacks queries

### DIFF
--- a/Endpoints/packs/windows-attacks.conf
+++ b/Endpoints/packs/windows-attacks.conf
@@ -12,32 +12,32 @@
       "description": "Searches for the presence of the 'Debugger' registry key for common Windows accessibility tools. More info: https://blogs.technet.microsoft.com/jonathantrull/2016/10/03/detecting-sticky-key-backdoors/"
     },
     "conhost.exe_incorrect_path": {
-      "query": "SELECT * FROM processes WHERE lower(name)='conhost.exe' AND lower(path)!='c:\\windows\\system32\\conhost.exe';",
+      "query": "SELECT * FROM processes WHERE LOWER(name)='conhost.exe' AND LOWER(path)!='c:\\windows\\system32\\conhost.exe' AND path!='';",
       "interval": 3600,
       "description": "Detect processes masquerading as legitimate Windows processes"
     },
     "dllhost.exe_incorrect_path": {
-      "query": "SELECT * FROM processes WHERE lower(name)='dllhost.exe' AND lower(path)!='c:\\windows\\system32\\dllhost.exe';",
+      "query": "SELECT * FROM processes WHERE LOWER(name)='dllhost.exe' AND LOWER(path)!='c:\\windows\\system32\\dllhost.exe' AND LOWER(path)!='c:\\windows\\syswow64\\dllhost.exe' AND path!='';",
       "interval": 3600,
       "description": "Detect processes masquerading as legitimate Windows processes"
     },
     "lsass.exe_incorrect_path": {
-      "query": "SELECT * FROM processes WHERE lower(name)='lsass.exe' AND lower(path)!='c:\\windows\\system32\\lsass.exe';",
+      "query": "SELECT * FROM processes WHERE LOWER(name)='lsass.exe' AND LOWER(path)!='c:\\windows\\system32\\lsass.exe' AND path!='';",
       "interval": 3600,
       "description": "Detect processes masquerading as legitimate Windows processes"
     },
     "services.exe_incorrect_parent_process": {
-      "query": "SELECT name FROM processes WHERE pid=(SELECT parent FROM processes WHERE lower(name)='services.exe') AND lower(name)!='wininit.exe';",
+      "query": "SELECT name FROM processes WHERE pid=(SELECT parent FROM processes WHERE LOWER(name)='services.exe') AND LOWER(name)!='wininit.exe';",
       "interval": 3600,
       "description": "Detect processes masquerading as legitimate Windows processes"
     },
     "svchost.exe_incorrect_path": {
-      "query": "SELECT * FROM processes WHERE lower(name)='svchost.exe' AND lower(path)!='c:\\windows\\system32\\svchost.exe' AND path!='';",
+      "query": "SELECT * FROM processes WHERE LOWER(name)='svchost.exe' AND LOWER(path)!='c:\\windows\\system32\\svchost.exe' AND LOWER(path)!='c:\\windows\\syswow64\\svchost.exe' AND path!='';",
       "interval": 3600,
       "description": "Detect processes masquerading as legitimate Windows processes"
     },
     "svchost.exe_incorrect_parent_process": {
-      "query": "SELECT name FROM processes WHERE pid=(SELECT parent FROM processes WHERE lower(name)='svchost.exe') AND lower(name)!='services.exe';",
+      "query": "SELECT name FROM processes WHERE pid=(SELECT parent FROM processes WHERE LOWER(name)='svchost.exe') AND LOWER(name)!='services.exe';",
       "interval": 3600,
       "description": "Detect processes masquerading as legitimate Windows processes"
     }


### PR DESCRIPTION
Occasionally osquery will report paths for processes as a blank line. This commit prevents those events from being logged.