### PR TITLE
Querycon update

### DIFF
--- a/Endpoints/MacOS/osquery.conf
+++ b/Endpoints/MacOS/osquery.conf
@@ -70,7 +70,7 @@
       "description": "List the contents of /etc/hosts"
     },
     "event_taps": {
-      "query": "SELECT * FROM event_taps INNER JOIN processes ON event_taps.tapping_process = processes.pid WHERE event_tapped NOT LIKE '%mouse%' AND processes.path NOT LIKE '%.app%' AND processes.path!='/Library/Application Support/org.pqrs/Karabiner-Elements/bin/karabiner_grabber' AND processes.path NOT LIKE '/Users/%/bin/kwm' AND processes.path!='/Library/Rapport/bin/rooksd' AND processes.path!='/usr/sbin/universalaccessd' AND processes.path NOT LIKE '/usr/local/Cellar/%' AND  processes.path NOT LIKE '/System/Library/%' AND processes.path NOT LIKE '%steamapps%' AND event_taps.enabled=1;",
+      "query": "SELECT * FROM event_taps INNER JOIN processes ON event_taps.tapping_process = processes.pid WHERE event_tapped NOT LIKE '%mouse%' AND processes.path NOT LIKE '%.app%' AND event_taps.enabled=1;",
       "interval": 300,
       "description": "Returns information about installed event taps. Can be used to detect keyloggers"
     },

--- a/Endpoints/MacOS/osquery.conf
+++ b/Endpoints/MacOS/osquery.conf
@@ -26,7 +26,7 @@
       "description": "List installed Chrome Extensions for all users"
     },
     "crashes": {
-      "query": "SELECT datetime, responsible, exception_type, identifier, version, crash_path, type FROM crashes;",
+      "query": "SELECT uid, datetime, responsible, exception_type, identifier, version, crash_path FROM users JOIN crashes USING (uid);",
       "interval": 3600,
       "description": "Application, System, and Mobile App crash logs.",
       "removed": false
@@ -70,8 +70,8 @@
       "description": "List the contents of /etc/hosts"
     },
     "event_taps": {
-      "query": "SELECT * FROM event_taps INNER JOIN processes ON event_taps.tapping_process = processes.pid WHERE processes.path NOT LIKE '%.app%' AND event_taps.enabled=1;",
-      "interval": 3600,
+      "query": "SELECT * FROM event_taps INNER JOIN processes ON event_taps.tapping_process = processes.pid WHERE event_tapped NOT LIKE '%mouse%' AND processes.path NOT LIKE '%.app%' AND processes.path!='/Library/Application Support/org.pqrs/Karabiner-Elements/bin/karabiner_grabber' AND processes.path NOT LIKE '/Users/%/bin/kwm' AND processes.path!='/Library/Rapport/bin/rooksd' AND processes.path!='/usr/sbin/universalaccessd' AND processes.path NOT LIKE '/usr/local/Cellar/%' AND  processes.path NOT LIKE '/System/Library/%' AND processes.path NOT LIKE '%steamapps%' AND event_taps.enabled=1;",
+      "interval": 300,
       "description": "Returns information about installed event taps. Can be used to detect keyloggers"
     },
     "file_events": {
@@ -153,16 +153,17 @@
       "description": "Snapshot query for macosx_kextstat",
       "snapshot": true
     },
-    "modified_rc_common": {
-      "query": "SELECT * FROM hash WHERE path='/etc/rc.common' AND md5!='28ce428faefe6168618867f3ff5527f9' AND md5!='';",
-      "interval": 3600,
-      "description": "Checks the MD5 hash of /etc/rc.common and records the results if the hash differs from the default value. /etc/rc.common can be used for persistence."
-    },
     "mounts": {
       "query": "SELECT device, device_alias, path, type, blocks_size FROM mounts;",
       "interval": 3600,
       "description": "System mounted devices and filesystems (not process specific).",
       "removed": false
+    },
+    "network_interfaces_snapshot": {
+      "query": "SELECT a.interface, a.address, d.mac FROM interface_addresses a JOIN interface_details d USING (interface);",
+      "interval": 600,
+      "description": "Retrieve the interface name, IP address, and MAC address for all interfaces on the host.",
+      "snapshot": true
     },
     "nfs_shares": {
       "query": "SELECT * FROM nfs_shares;",
@@ -208,6 +209,17 @@
       "query": "SELECT * FROM python_packages;",
       "interval": 3600,
       "description": "Python packages installed in a system."
+    },
+    "rc.common": {
+      "query": "SELECT * FROM hash WHERE path='/etc/rc.common' AND md5!='28ce428faefe6168618867f3ff5527f9' and md5!='';",
+      "interval": 3600,
+      "description": "Checks the MD5 hash of /etc/rc.common and records the results if the hash differs from the default value. /etc/rc.common can be used for persistence."
+    },
+    "rc.common_snapshot": {
+      "query": "SELECT * FROM hash WHERE path='/etc/rc.common' AND md5!='28ce428faefe6168618867f3ff5527f9' and md5!='';",
+      "interval": 28800,
+      "description": "Checks the MD5 hash of /etc/rc.common and records the results if the hash differs from the default value. /etc/rc.common can be used for persistence.",
+      "snapshot": true
     },
     "safari_extensions": {
       "query": "SELECT * FROM users JOIN safari_extensions USING (uid);",

--- a/Endpoints/Windows/osquery.conf
+++ b/Endpoints/Windows/osquery.conf
@@ -53,6 +53,12 @@
       "interval": 3600,
       "description": "List the kernel path, version, etc."
     },
+    "network_interfaces_snapshot": {
+      "query": "SELECT a.interface, a.address, d.mac FROM interface_addresses a JOIN interface_details d USING (interface);",
+      "interval": 600,
+      "description": "Retrieve the interface name, IP address, and MAC address for all interfaces on the host.",
+      "snapshot": true
+    },
     "os_version": {
       "query": "SELECT * FROM os_version;",
       "interval": 3600,
@@ -140,6 +146,12 @@
       "interval": 28800,
       "description": "Users snapshot query",
       "snapshot": true
+    },
+    "windows_crashes": {
+      "query": "SELECT * FROM windows_crashes;",
+      "interval": 3600,
+      "description": "Extracted information from Windows crash logs (Minidumps).",
+      "removed": false
     },
     "wmi_cli_event_consumers": {
       "query": "SELECT * FROM wmi_cli_event_consumers;",

--- a/Endpoints/packs/security-tooling-checks.conf
+++ b/Endpoints/packs/security-tooling-checks.conf
@@ -1,19 +1,19 @@
 {
   "queries": {
-    "EndpointSecurityTool_BackendServer_Registry_Misconfigured": {
+    "endpoint_security_tool_backend_server_registry_misconfigured": {
       "query": "SELECT * FROM registry WHERE path='HKEY_LOCAL_MACHINE\\Software\\EndpointSecurityTool\\BackendServerLocation' AND data!='https://expected_endpoint.local';",
       "interval": 3600,
       "description": "Returns the content of the key if the backend server does not match the expected value",
       "platform": "windows"
     },
-    "EndpointSecurityTool_Not_Running": {
+    "endpoint_security_tool_not_running": {
       "query": "SELECT IFNULL(process_count,0) as process_exists FROM (SELECT count(*) as process_count from processes where path='/Applications/EndpointSecurityTool' OR lower(path)='c:\\endpointsecuritytool.exe') where process_exists!=1;",
       "interval": 28800,
       "description": "Returns an event if a EndpointSecurityTool process is not found running from /Applications/EndpointSecurityTool' (OSX) or 'c:\\endpointsecuritytool.exe' (Windows)",
       "platform": "windows,darwin",
       "snapshot": true
     },
-    "BackupTool_Not_Running": {
+    "backup_tool_not_running": {
       "query": "SELECT IFNULL(process_count,0) as process_exists FROM (SELECT count(*) as process_count from processes where path='/Applications/BackupTool' OR lower(path) LIKE 'c:\\backuptool.exe') where process_exists!=1;",
       "interval": 28800,
       "description": "Returns an event if a BackupTool process is not found running from '/Applications/BackupTool' (OSX) or 'c:\backuptool.exe' (Windows)",

--- a/Endpoints/packs/windows-application-security.conf
+++ b/Endpoints/packs/windows-application-security.conf
@@ -1,37 +1,37 @@
 {
   "platform": "windows",
   "queries": {
-    "Bitlocker_AutoEncrypt_Settings_Registry": {
+    "bitlocker_autoencrypt_settings_registry": {
       "query": "SELECT * FROM registry WHERE key LIKE 'HKEY_LOCAL_MACHINE\\System\\CurrentControlSet\\Control\\Bitlocker\\%%';",
       "interval": 3600,
       "description": "Controls Bitlocker full-disk encryption settings."
     },
-    "Bitlocker_FDE_Settings_Registry": {
+    "bitlocker_fde_settings_registry": {
       "query": "SELECT * FROM registry WHERE key LIKE 'HKEY_LOCAL_MACHINE\\Software\\Policies\\Microsoft\\FVE\\%%';",
       "interval": 3600,
       "description": "Controls Bitlocker full-disk encryption settings."
     },
-    "Chrome_Extension_ForceList_Registry": {
+    "chrome_extension_force_list_registry": {
       "query": "SELECT * FROM registry WHERE key='HKEY_LOCAL_MACHINE\\Software\\Policies\\Google\\Chrome\\ExtensionInstallForcelist';",
       "interval": 3600,
       "description": "Controls Google Chrome plugins that are forcibly installed."
     },
-    "EMET_Settings_Registry": {
+    "emet_settings_registry": {
       "query": "SELECT * FROM registry WHERE key LIKE 'HKEY_LOCAL_MACHINE\\Software\\Policies\\Microsoft\\EMET\\%%';",
       "interval": 3600,
       "description": "Controls EMET-protected applications and system settings."
     },
-    "Microsoft_LAPS_Settings_Registry": {
+    "microsoft_laps_settings_registry": {
       "query": "SELECT * FROM registry WHERE key='HKEY_LOCAL_MACHINE\\Software\\Policies\\Microsoft Services\\AdmPwd';",
       "interval": 3600,
       "description": "Controls Local Administrative Password Solution (LAPS) settings."
     },
-    "Passport_For_Work_Settings_Registry": {
+    "passport_for_work_settings_registry": {
       "query": "SELECT * FROM registry WHERE path LIKE 'HKEY_LOCAL_MACHINE\\Software\\Policies\\Microsoft\\PassportForWork\\%%';",
       "interval": 3600,
       "description": "Controls Windows Passport for Work (Hello) settings."
     },
-    "UAC_Settings_Registry": {
+    "uac_settings_registry": {
       "query": "SELECT * FROM registry WHERE path='HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\EnableLUA';",
       "interval": 3600,
       "description": "Controls UAC. A setting of 0 indicates that UAC is disabled."

--- a/Endpoints/packs/windows-compliance.conf
+++ b/Endpoints/packs/windows-compliance.conf
@@ -1,112 +1,112 @@
 {
   "platform": "windows",
   "queries": {
-    "Command_Line_Auditing_Registry": {
+    "command_line_auditing_registry": {
       "query": "SELECT * FROM registry WHERE key='HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\Audit';",
       "interval": 3600,
       "description": "Controls Windows command-line auditing"
     },
-    "Crash_Dump_Registry": {
+    "crash_dump_registry": {
       "query": "SELECT * FROM registry WHERE path='HKEY_LOCAL_MACHINE\\System\\CurrentControlSet\\Control\\CrashControl\\CrashDumpEnabled';",
       "interval": 3600,
       "description": "Controls enabling/disabling crash dumps. This key has a default value of 7, but some malware sets this value to 0. See: https://www.documentcloud.org/documents/3477047-Document-07-Neel-Mehta-Billy-Leonard-and-Shane.html"
     },
-    "DNS_Plugin_DLL_Registry": {
+    "dns_plugin_dll_registry": {
       "query": "SELECT * FROM registry WHERE key='HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\services\\DNS\\Parameters\\ServerLevelPluginDll';",
       "interval": 3600,
       "description": "This registry key specifies the path to a DLL to be loaded by a Windows DNS server. This key does not exist by default. Can allow privesc: https://medium.com/@esnesenon/feature-not-bug-dnsadmin-to-dc-compromise-in-one-line-a0f779b8dc83"
     },
-    "Dr_Watson_Registry": {
+    "dr_watson_registry": {
       "query": "SELECT * FROM registry WHERE key='HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\AeDebug';",
       "interval": 3600,
       "description": "This key (and subkeys) exist by default and are required to allow post-mortem debuggers like Dr. Watson. Some malware deletes this key. See: https://www.documentcloud.org/documents/3477047-Document-07-Neel-Mehta-Billy-Leonard-and-Shane.html"
     },
-    "Error_Display_UI_Registry": {
+    "error_display_ui_registry": {
       "query": "SELECT * FROM registry WHERE path='HKEY_LOCAL_MACHINE\\Software\\Microsoft\\PCHealth\\ErrorReporting\\ShowUI';",
       "interval": 3600,
       "description": "This key does not exist by default and controls enabling/disabling error reporting display. Some malware creates this key and sets the value to 0. See: https://www.documentcloud.org/documents/3477047-Document-07-Neel-Mehta-Billy-Leonard-and-Shane.html"
     },
-    "Error_Mode_Registry": {
+    "error_mode_registry": {
       "query": "SELECT * FROM registry WHERE path='HKEY_LOCAL_MACHINE\\System\\CurrentControlSet\\Control\\Windows\\ErrorMode';",
       "interval": 3600,
       "description": "Controls the suppression of error dialog boxes. The default value is 0 (all messages are visible), but some malware sets this value to 2 (all messages are invisible). See: https://www.documentcloud.org/documents/3477047-Document-07-Neel-Mehta-Billy-Leonard-and-Shane.html"
     },
-    "Error_Report_Registry": {
+    "error_report_registry": {
       "query": "SELECT * FROM registry WHERE path='HKEY_LOCAL_MACHINE\\Software\\Microsoft\\PCHealth\\ErrorReporting\\DoReport';",
       "interval": 3600,
       "description": "This key does not exist by default and controls enabling/disabling error reporting. Some malware creates this key sets the value to 0 (disables error reports). See https://msdn.microsoft.com/en-us/library/aa939342(v=winembedded.5).aspx and https://www.documentcloud.org/documents/3477047-Document-07-Neel-Mehta-Billy-Leonard-and-Shane.html"
     },
-    "Event_Log_Settings_Registry": {
+    "event_log_settings_registry": {
       "query": "SELECT * FROM registry WHERE key LIKE 'HKEY_LOCAL_MACHINE\\Software\\Policies\\Microsoft\\Windows\\EventLog\\%%';",
       "interval": 3600,
       "description": "Controls behavior, size, and rotation strategy for primary windows event log files."
     },
-    "FileRenameOperations_Registry": {
+    "filerenameoperations_registry": {
       "query": "SELECT * FROM registry WHERE path='HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\FileRenameOperations';",
       "interval": 3600,
       "description": "Entries for the FileRenameOperation support the MoveFileEx delayed-rename and delayed-delete capabilities. Sometimes used as a self-deletion technique for malware."
     },
-    "KnownDLLs_Registry": {
+    "knowndlls_registry": {
       "query": "SELECT * FROM registry WHERE path LIKE 'HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\KnownDLLs\\%%';",
       "interval": 3600,
       "description": "The KnownDlls key defines the set of DLLs that are first searched during system startup."
     },
-    "Local_Security_Authority_Registry": {
+    "local_security_authority_registry": {
       "query": "SELECT * FROM registry WHERE key LIKE 'HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Lsa\\%%';",
       "interval": 3600,
       "description": "Controls which security packages store credentials in LSA memory, secure boot, etc."
     },
-    "Log_Errors_Registry": {
+    "log_errors_registry": {
       "query": "SELECT * FROM registry WHERE path='HKEY_LOCAL_MACHINE\\System\\CurrentControlSet\\Control\\CrashControl\\LogEvent';",
       "interval": 3600,
       "description": "This key exists by default and has a default value of 1. Setting this key to 0 disables logging errors/crashes to the System event channel. Some malware sets this value to 0. See: https://www.documentcloud.org/documents/3477047-Document-07-Neel-Mehta-Billy-Leonard-and-Shane.html"
     },
-    "Per_User_TS_Session_Registry": {
+    "per_user_ts_session_registry": {
       "query": "SELECT * FROM registry WHERE path='HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Terminal Server\\fSingleSessionPerUser';",
       "interval": 3600,
       "description": "Controls how many simultaneous terminal services sessions can use the same account"
     },
-    "Powershell_Settings_Registry": {
+    "powershell_settings_registry": {
       "query": "SELECT * FROM registry WHERE key LIKE 'HKEY_LOCAL_MACHINE\\Software\\Policies\\Microsoft\\Windows\\Powershell\\%%';",
       "interval": 3600,
       "description": "Controls Powershell execution policy, script execution, logging, and more."
     },
-    "SMBv1_Registry": {
+    "smbv1_registry": {
       "query": "SELECT * FROM registry WHERE path='HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\LanmanServer\\Parameters\\SMB1';",
       "interval": 3600,
       "description": "Controls enabling/disabling SMBv1. Setting this key to 0 disables the SMBv1 protocol on the host."
     },
-    "Secure_Boot_Registry": {
+    "secure_boot_registry": {
       "query": "SELECT * FROM registry WHERE key='HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\SecureBoot';",
       "interval": 3600,
       "description": "Lists information about SecureBoot status."
     },
-    "Security_Providers_Registry": {
+    "security_providers_registry": {
       "query": "SELECT * FROM registry WHERE key LIKE 'HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\SecurityProviders\\%%';",
       "interval": 3600,
       "description": "Controls Windows security provider configurations"
     },
-    "Send_Error_Alert_Registry": {
+    "send_error_alert_registry": {
       "query": "SELECT * FROM registry WHERE path='HKEY_LOCAL_MACHINE\\System\\CurrentControlSet\\Control\\CrashControl\\SendAlert';",
       "interval": 3600,
       "description": "Controls sending administrative notifications after a crash. Some malware sets this value to 0"
     },
-    "TPM_Registry": {
+    "tpm_registry": {
       "query": "SELECT * FROM registry WHERE key='HKEY_LOCAL_MACHINE\\Software\\Policies\\Microsoft\\TPM';",
       "interval": 3600,
       "description": "Controls system TPM settings"
     },
-    "Terminal_Service_Deny_Registry": {
+    "terminal_service_deny_registry": {
       "query": "SELECT * FROM registry WHERE path='HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Terminal Server\\fDenyTSConnections';",
       "interval": 3600,
       "description": "This key exists by default and has a default value of 1. Terminal service connections are allowed to the host when the key value is set to 0"
     },
-    "WinRM_Settings_Registry": {
+    "winrm_settings_registry": {
       "query": "SELECT * FROM registry WHERE key LIKE 'HKEY_LOCAL_MACHINE\\Software\\Policies\\Microsoft\\Windows\\WinRM\\%%';",
       "interval": 3600,
       "description": "Controls local WinRM client configuration and security."
     },
-    "Windows_Update_Settings_Registry": {
+    "windows_update_settings_registry": {
       "query": "SELECT * FROM registry WHERE key LIKE 'HKEY_LOCAL_MACHINE\\Software\\Policies\\Microsoft\\Windows\\WindowsUpdate\\%%';",
       "interval": 3600,
       "description": "Controls Windows Update server location and installation behavior."

--- a/Endpoints/packs/windows-registry-monitoring.conf
+++ b/Endpoints/packs/windows-registry-monitoring.conf
@@ -1,163 +1,175 @@
 {
   "platform": "windows",
   "queries": {
-    "Bitlocker_Encryption_Settings_Registry_Misconfigured": {
+    "bitlocker_encryption_settings_registry_misconfigured": {
       "query": "SELECT * FROM registry WHERE (path='HKEY_LOCAL_MACHINE\\Software\\Policies\\Microsoft\\FVE\\MDOPBitLockerManagement\\ShouldEncryptOSDrive' OR path='HKEY_LOCAL_MACHINE\\Software\\Policies\\Microsoft\\FVE\\MDOPBitLockerManagement\\OSDriveProtector') AND data!=1;",
       "interval": 3600,
       "description": "Returns the content of the key if it does not match the expected value",
       "platform": "windows"
     },
-    "Bitlocker_MBAM_Endpoint_Registry_Misconfigured": {
+    "bitlocker_mbam_endpoint_registry_misconfigured": {
       "query": "SELECT * FROM registry WHERE path='HKEY_LOCAL_MACHINE\\Software\\Policies\\Microsoft\\FVE\\MDOPBitLockerManagement\\KeyRecoveryServiceEndPoint' AND data!='https://mbam.server.com/MBAMRecoveryAndHardwareService/CoreService.svc';",
       "interval": 3600,
       "description": "Returns the content of the key if it does not match the expected value",
       "platform": "windows"
     },
-    "Bitlocker_MBAM_Registry_Misconfigured": {
+    "bitlocker_mbam_registry_misconfigured": {
       "query": "SELECT * FROM registry WHERE path='HKEY_LOCAL_MACHINE\\Software\\Policies\\Microsoft\\FVE\\MDOPBitLockerManagement\\UseMBAMServices' AND data!=1;",
       "interval": 3600,
       "description": "Returns the content of the key if it does not match the expected value",
       "platform": "windows"
     },
-    "Command_Line_Auditing_Registry_Misconfigured": {
+    "command_line_auditing_registry_misconfigured": {
       "query": "SELECT * FROM registry WHERE path='HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\Audit\\ProcessCreationIncludeCmdLine_Enabled' AND data!=1;",
       "interval": 3600,
       "description": "Returns the content of the key if it does not match the expected value",
       "platform": "windows"
     },
-    "Command_Line_Auditing_Registry_Missing": {
+    "command_line_auditing_registry_missing": {
       "query": "SELECT IFNULL(key_count,0) AS key_exists FROM (SELECT COUNT(*) AS key_count FROM registry WHERE path='HKEY_LOCAL_MACHINE\\Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\System\\Audit\\ProcessCreationIncludeCmdLine_Enabled') WHERE key_exists!=1;",
       "interval": 3600,
       "description": "Returns 0 as a result if the registry key does not exist",
       "platform": "windows"
     },
-    "Crash_Dump_Registry_Misconfigured": {
+    "crash_dump_registry_misconfigured": {
       "query": "SELECT * FROM registry WHERE path='HKEY_LOCAL_MACHINE\\System\\CurrentControlSet\\Control\\CrashControl\\CrashDumpEnabled' AND data=0;",
       "interval": 3600,
       "description": "Returns the content of the key if it does not match the expected value",
       "platform": "windows"
     },
-    "Crash_Dump_Registry_Missing": {
+    "crash_dump_registry_missing": {
       "query": "SELECT IFNULL(key_count,0) AS key_exists FROM (SELECT COUNT(*) AS key_count FROM registry WHERE path='HKEY_LOCAL_MACHINE\\System\\CurrentControlSet\\Control\\CrashControl\\CrashDumpEnabled') WHERE key_exists!=1;",
       "interval": 3600,
       "description": "Returns 0 as a result if the registry key does not exist",
       "platform": "windows"
     },
-    "DNS_Plugin_DLL_Registry_Exists": {
+    "dns_plugin_dll_registry_exists": {
       "query": "SELECT * FROM registry WHERE key='HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\services\\DNS\\Parameters\\ServerLevelPluginDll';",
       "interval": 3600,
       "description": "Returns the content of this key if it exists, which it shouldn't by default",
       "platform": "windows"
     },
-    "Dr_Watson_Registry_Missing": {
+    "dr_watson_registry_missing": {
       "query": "SELECT IFNULL(key_count,0) AS key_exists FROM (SELECT COUNT(*) AS key_count FROM registry where key='HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\AeDebug') WHERE key_exists!=2;",
       "interval": 3600,
       "description": "Returns 0 as a result if the registry key does not exist",
       "platform": "windows"
     },
-    "Error_Display_UI_Registry_Exists": {
+    "error_display_ui_registry_exists": {
       "query": "SELECT * FROM registry WHERE path='HKEY_LOCAL_MACHINE\\Software\\Microsoft\\PCHealth\\ErrorReporting\\ShowUI';",
       "interval": 3600,
       "description": "Returns the content of this key if it exists, which it shouldn't by default",
       "platform": "windows"
     },
-    "Error_Mode_Registry_Misconfigured": {
+    "error_mode_registry_misconfigured": {
       "query": "SELECT * FROM registry WHERE path='HKEY_LOCAL_MACHINE\\System\\CurrentControlSet\\Control\\Windows\\ErrorMode' AND data=2;",
       "interval": 3600,
       "description": "Returns the content of the key if it does not match the expected value",
       "platform": "windows"
     },
-    "Error_Mode_Registry_Missing": {
+    "error_mode_registry_missing": {
       "query": "SELECT IFNULL(key_count,0) AS key_exists FROM (SELECT COUNT(*) AS key_count FROM registry WHERE path='HKEY_LOCAL_MACHINE\\System\\CurrentControlSet\\Control\\Windows\\ErrorMode') WHERE key_exists!=1;",
       "interval": 3600,
       "description": "Returns 0 as a result if the registry key does not exist",
       "platform": "windows"
     },
-    "Log_Errors_Registry_Misconfigured": {
+    "log_errors_registry_misconfigured": {
       "query": "SELECT * FROM registry WHERE path='HKEY_LOCAL_MACHINE\\System\\CurrentControlSet\\Control\\CrashControl\\LogEvent' AND data!=1;",
       "interval": 3600,
       "description": "Returns the content of the key if it does not match the expected value",
       "platform": "windows"
     },
-    "Log_Errors_Registry_Missing": {
+    "log_errors_registry_missing": {
       "query": "SELECT IFNULL(key_count,0) AS key_exists FROM (SELECT COUNT(*) AS key_count FROM registry WHERE path='HKEY_LOCAL_MACHINE\\System\\CurrentControlSet\\Control\\CrashControl\\LogEvent') WHERE key_exists!=1;",
       "interval": 3600,
       "description": "Returns 0 as a result if the registry key does not exist",
       "platform": "windows"
     },
-    "Per_User_TS_Session_Registry_Misconfigured": {
+    "per_user_ts_session_registry_misconfigured": {
       "query": "SELECT * FROM registry WHERE path='HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Terminal Server\\fSingleSessionPerUser' AND data!=1;",
       "interval": 3600,
       "description": "Returns the content of the key if it does not match the expected value",
       "platform": "windows"
     },
-    "Per_User_TS_Session_Registry_Missing": {
+    "per_user_ts_session_registry_missing": {
       "query": "SELECT IFNULL(key_count,0) AS key_exists FROM (SELECT COUNT(*) AS key_count FROM registry WHERE path='HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Terminal Server\\fSingleSessionPerUser') WHERE key_exists!=1;",
       "interval": 3600,
       "description": "Returns 0 as a result if the registry key does not exist",
       "platform": "windows"
     },
-    "Powershell_InvocationHeader_Registry_Missing": {
+    "physicalstore_dll_registry_persistence": {
+      "query": "SELECT key, path, name, mtime, username FROM registry r, users WHERE path LIKE 'HKEY_USERS\\'||uuid||'\\Software\\Microsoft\\SystemCertificates\\CA\\PhysicalStores\\%%' OR path LIKE 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Cryptography\\OID\\EncodingType 0\\CertDllOpenStoreProv\\%%' AND name!='#16' AND name!='Ldap';",
+      "interval": 3600,
+      "description": "Detect a registry based persistence mechanism that allows an attacker to specify a DLL to be loaded when cryptographic libraries are called (https://twitter.com/PsiDragon/status/978367732793135105)",
+      "platform": "windows"
+    },
+    "powershell_invocationheader_registry_missing": {
       "query": "SELECT IFNULL(key_count,0) AS key_exists FROM (SELECT COUNT(*) AS key_count FROM registry WHERE path='HKEY_LOCAL_MACHINE\\Software\\Policies\\Microsoft\\Windows\\Powershell\\Transcription\\EnableInvocationHeader') WHERE key_exists!=1;",
       "interval": 3600,
       "description": "Returns 0 as a result if the registry key does not exist",
       "platform": "windows"
     },
-    "Powershell_Logging_Registry_Misconfigured": {
+    "powershell_logging_registry_misconfigured": {
       "query": "SELECT * FROM registry WHERE (path='HKEY_LOCAL_MACHINE\\Software\\Policies\\Microsoft\\Windows\\Powershell\\ModuleLogging\\EnableModuleLogging' OR path='HKEY_LOCAL_MACHINE\\Software\\Policies\\Microsoft\\Windows\\Powershell\\ScriptBlockLogging\\EnableScriptBlockLogging' OR path='HKEY_LOCAL_MACHINE\\Software\\Policies\\Microsoft\\Windows\\Powershell\\Transcription\\EnableTranscripting' OR path='HKEY_LOCAL_MACHINE\\Software\\Policies\\Microsoft\\Windows\\Powershell\\Transcription\\EnableInvocationHeader') AND data!=1;",
       "interval": 3600,
       "description": "Returns the content of the key if it does not match the expected value",
       "platform": "windows"
     },
-    "Powershell_ModuleLogging_Registry_Missing": {
+    "powershell_module_logging_registry_missing": {
       "query": "SELECT IFNULL(key_count,0) AS key_exists FROM (SELECT COUNT(*) AS key_count FROM registry WHERE path='HKEY_LOCAL_MACHINE\\Software\\Policies\\Microsoft\\Windows\\Powershell\\ModuleLogging\\EnableModuleLogging') WHERE key_exists!=1;",
       "interval": 3600,
       "description": "Returns 0 as a result if the registry key does not exist",
       "platform": "windows"
     },
-    "Powershell_ScriptBlockLogging_Registry_Missing": {
+    "powershell_scriptblock_logging_registry_missing": {
       "query": "SELECT IFNULL(key_count,0) AS key_exists FROM (SELECT COUNT(*) AS key_count FROM registry WHERE path='HKEY_LOCAL_MACHINE\\Software\\Policies\\Microsoft\\Windows\\Powershell\\ScriptBlockLogging\\EnableScriptBlockLogging') WHERE key_exists!=1;",
       "interval": 3600,
       "description": "Returns 0 as a result if the registry key does not exist",
       "platform": "windows"
     },
-    "Powershell_TranscriptingLogging_Registry_Missing": {
+    "powershell_transcription_logging_registry_missing": {
       "query": "SELECT IFNULL(key_count,0) AS key_exists FROM (SELECT COUNT(*) AS key_count FROM registry WHERE path='HKEY_LOCAL_MACHINE\\Software\\Policies\\Microsoft\\Windows\\Powershell\\Transcription\\EnableTranscripting') WHERE key_exists!=1;",
       "interval": 3600,
       "description": "Returns 0 as a result if the registry key does not exist",
       "platform": "windows"
     },
-    "SMBv1_Registry_Misconfigured": {
+    "runonceex_persistence_registry": {
+      "query": "SELECT * FROM registry WHERE path = 'HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\RunOnceEx';",
+      "interval": 3600,
+      "description": "Registry based persistence mechanism to load DLLs at reboot time and avoids detection by Autoruns (https://oddvar.moe/2018/03/21/persistence-using-runonceex-hidden-from-autoruns-exe/). Subkeys will be deleted after they run, thus (RunOnce). The RunOnceEx key will remain.",
+      "platform": "windows"
+    },
+    "smbv1_registry_misconfigured": {
       "query": "SELECT * FROM registry WHERE path='HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\LanmanServer\\Parameters\\SMB1' AND data!=0;",
       "interval": 3600,
       "description": "",
       "platform": "windows"
     },
-    "SMBv1_Registry_Missing": {
+    "smbv1_registry_missing": {
       "query": "SELECT IFNULL(key_count,0) AS key_exists FROM (SELECT COUNT(*) AS key_count FROM registry WHERE path='HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Services\\LanmanServer\\Parameters\\SMB1') WHERE key_exists!=1;",
       "interval": 3600,
       "description": "Returns 0 as a result if the registry key does not exist",
       "platform": "windows"
     },
-    "Send_Error_Alert_Registry_Exists": {
+    "send_error_alert_registry_exists": {
       "query": "SELECT * FROM registry WHERE key='HKEY_LOCAL_MACHINE\\System\\CurrentControlSet\\Control\\CrashControl\\SendAlert';",
       "interval": 3600,
       "description": "Returns the content of this key if it exists, which it shouldn't by default",
       "platform": "windows"
     },
-    "Subscription_Manager_Registry_Misconfigured": {
+    "subscription_manager_registry_misconfigured": {
       "query": "SELECT * FROM registry WHERE path='HKEY_LOCAL_MACHINE\\Software\\Policies\\Microsoft\\Windows\\EventLog\\EventForwarding\\SubscriptionManager\\1' AND (data!='Server=http://subdomain.domain.com:5985/wsman/SubscriptionManager/WEC' AND data!='Server=http://subdomain.domain.com:5985/wsman/SubscriptionManager/WEC');",
       "interval": 3600,
       "description": "Returns the content of the key if it does not match the expected value",
       "platform": "windows"
     },
-    "Subscription_Manager_Registry_Missing": {
+    "subscription_manager_registry_missing": {
       "query": "SELECT IFNULL(key_count,0) AS key_exists FROM (SELECT COUNT(*) AS key_count FROM registry WHERE path='HKEY_LOCAL_MACHINE\\Software\\Policies\\Microsoft\\Windows\\EventLog\\EventForwarding\\SubscriptionManager\\1') WHERE key_exists!=1;",
       "interval": 3600,
       "description": "Returns 0 as a result if the registry key does not exist",
       "platform": "windows"
     },
-    "WinRM_Settings_Registry_Misconfigured": {
+    "winrm_settings_registry_misconfigured": {
       "query": "SELECT * FROM registry WHERE (path='HKEY_LOCAL_MACHINE\\Software\\Policies\\Microsoft\\Windows\\WinRM\\Client\\AllowBasic' OR path='HKEY_LOCAL_MACHINE\\Software\\Policies\\Microsoft\\Windows\\WinRM\\Client\\AllowCredSSP' OR path='HKEY_LOCAL_MACHINE\\Software\\Policies\\Microsoft\\Windows\\WinRM\\Client\\AllowUnencryptedTraffic' OR path='HKEY_LOCAL_MACHINE\\Software\\Policies\\Microsoft\\Windows\\WinRM\\Client\\AllowDigest' OR path='HKEY_LOCAL_MACHINE\\Software\\Policies\\Microsoft\\Windows\\WinRM\\Service\\AllowBasic' OR path='HKEY_LOCAL_MACHINE\\Software\\Policies\\Microsoft\\Windows\\WinRM\\Service\\AllowCredSSP' OR path='HKEY_LOCAL_MACHINE\\Software\\Policies\\Microsoft\\Windows\\WinRM\\Service\\AllowUnencryptedTraffic' OR path='HKEY_LOCAL_MACHINE\\Software\\Policies\\Microsoft\\Windows\\WinRM\\Service\\WinRS\\AllowRemoteShellAccess') AND data!=0; ",
       "interval": 3600,
       "description": "Returns the content of the key if it does not match the expected value",

--- a/README.md
+++ b/README.md
@@ -17,13 +17,11 @@ operators have carefully considered the datasets to be collected and the potenti
 * [windows-registry-monitoring.conf](https://github.com/palantir/osquery-configuration/blob/master/Endpoints/packs/windows-registry-monitoring.conf)
 
 
-**Note**: This repository also contains copies of packs that are maintained in the official osquery project in order to save users time from having to download packs from two different locations when testing our configs:
+**Note**: We also utilize packs that are maintained in the official osquery project. In order to ensure you receive the most up to date version of the pack, please view them using the links below:
 * [ossec-rootkit.conf](https://github.com/facebook/osquery/blob/master/packs/ossec-rootkit.conf)
 * [osx-attacks.conf](https://github.com/facebook/osquery/blob/master/packs/osx-attacks.conf)
 * [unwanted-chrome-extensions.conf](https://github.com/facebook/osquery/blob/master/packs/unwanted-chrome-extensions.conf)
 * [windows-attacks.conf](https://github.com/facebook/osquery/blob/master/packs/windows-attacks.conf)
-
-These packs may not be kept up to date in this repository, so please be sure to download them from the official osquery repository if you desire the most up to date pack content.
 
 ## Repository Layout
 This repository is organized as follows:

--- a/Servers/Linux/osquery.conf
+++ b/Servers/Linux/osquery.conf
@@ -144,7 +144,7 @@
       "description": "Information about memory usage on the system"
     },
     "mounts": {
-      "query": "SELECT device, device_alias,path,type,blocks_size,flags FROM mounts;",
+      "query": "SELECT device, device_alias, path, type, blocks_size, flags FROM mounts;",
       "interval" : 86400,
       "description": "Retrieves the current list of mounted drives in the target system."
     },

--- a/Servers/Linux/osquery.conf
+++ b/Servers/Linux/osquery.conf
@@ -19,9 +19,14 @@
       "removed":false
     },
     "authorized_keys": {
-      "query" : "SELECT * FROM users JOIN authorized_keys USING (uid);",
+      "query": "SELECT * FROM users JOIN authorized_keys USING (uid);",
       "interval" : 86400,
-      "description" : "A line-delimited authorized_keys table."
+      "description": "A line-delimited authorized_keys table."
+    },
+    "behavioral_reverse_shell": {
+      "query" : "SELECT DISTINCT(processes.pid), processes.parent, processes.name, processes.path, processes.cmdline, processes.cwd, processes.root, processes.uid, processes.gid, processes.start_time, process_open_sockets.remote_address, process_open_sockets.remote_port, (SELECT cmdline FROM processes AS parent_cmdline WHERE pid=processes.parent) AS parent_cmdline FROM processes JOIN process_open_sockets USING (pid) LEFT OUTER JOIN process_open_files ON processes.pid = process_open_files.pid WHERE (name='sh' OR name='bash') AND remote_address NOT IN ('0.0.0.0', '::', '') AND remote_address NOT LIKE '10.%' AND remote_address NOT LIKE '192.168.%';",
+      "interval" : 600,
+      "description" : "Find shell processes that have open sockets"
     },
     "cpu_time": {
       "query": "SELECT * FROM cpu_time;",
@@ -29,14 +34,14 @@
       "description": "Displays information from /proc/stat file about the time the CPU cores spent in different parts of the system"
     },
     "crontab": {
-      "query" : "SELECT * FROM crontab;",
+      "query": "SELECT * FROM crontab;",
       "interval" : 3600,
-      "description" : "Retrieves all the jobs scheduled in crontab in the target system."
+      "description": "Retrieves all the jobs scheduled in crontab in the target system."
     },
     "crontab_snapshot": {
-      "query" : "SELECT * FROM crontab;",
+      "query": "SELECT * FROM crontab;",
       "interval" : 86400,
-      "description" : "Retrieves all the jobs scheduled in crontab in the target system.",
+      "description": "Retrieves all the jobs scheduled in crontab in the target system.",
       "snapshot": true
     },
     "deb_packages": {
@@ -52,36 +57,36 @@
       "description": "DNS resolvers used by the host"
     },
     "ec2_instance_metadata": {
-      "query" : "SELECT * FROM ec2_instance_metadata;",
+      "query": "SELECT * FROM ec2_instance_metadata;",
       "interval" : 3600,
-      "description" : "Retrieve the EC2 metadata for this endpoint"
+      "description": "Retrieve the EC2 metadata for this endpoint"
     },
     "ec2_instance_metadata_snapshot": {
-      "query" : "SELECT * FROM ec2_instance_metadata;",
+      "query": "SELECT * FROM ec2_instance_metadata;",
       "interval" : 86400,
-      "description" : "Snapshot query to retrieve the EC2 metadata for this endpoint",
+      "description": "Snapshot query to retrieve the EC2 metadata for this endpoint",
       "snapshot" : true
     },
     "ec2_instance_tags": {
-      "query" : "SELECT * FROM ec2_instance_tags;",
+      "query": "SELECT * FROM ec2_instance_tags;",
       "interval" : 3600,
-      "description" : "Retrieve the EC2 tags for this endpoint"
+      "description": "Retrieve the EC2 tags for this endpoint"
     },
     "ec2_instance_tags_snapshot": {
-      "query" : "SELECT * FROM ec2_instance_tags;",
+      "query": "SELECT * FROM ec2_instance_tags;",
       "interval" : 86400,
-      "description" : "Snapshot query to retrieve the EC2 tags for this instance",
+      "description": "Snapshot query to retrieve the EC2 tags for this instance",
       "snapshot" : true
     },
     "etc_hosts": {
-      "query" : "SELECT * FROM etc_hosts;",
+      "query": "SELECT * FROM etc_hosts;",
       "interval" : 86400,
-      "description" : "Retrieves all the entries in the target system /etc/hosts file."
+      "description": "Retrieves all the entries in the target system /etc/hosts file."
     },
     "etc_hosts_snapshot": {
-      "query" : "SELECT * FROM etc_hosts;",
+      "query": "SELECT * FROM etc_hosts;",
       "interval" : 86400,
-      "description" : "Retrieves all the entries in the target system /etc/hosts file.",
+      "description": "Retrieves all the entries in the target system /etc/hosts file.",
       "snapshot" : true
     },
     "hardware_events": {
@@ -90,21 +95,21 @@
       "removed":false
     },
     "iptables": {
-      "query" : "SELECT * FROM iptables;",
+      "query": "SELECT * FROM iptables;",
       "interval" : 86400,
-      "platform" : "linux",
-      "description" : "Retrieves the current filters and chains per filter in the target system."
+      "platform": "linux",
+      "description": "Retrieves the current filters and chains per filter in the target system."
     },
     "kernel_info": {
-      "query" : "SELECT * FROM kernel_info;",
+      "query": "SELECT * FROM kernel_info;",
       "interval" : 86400,
-      "description" : "Retrieves information from the current kernel in the target system.",
+      "description": "Retrieves information from the current kernel in the target system.",
       "snapshot" : true
     },
     "kernel_integrity": {
-      "query" : "SELECT * FROM kernel_integrity;",
+      "query": "SELECT * FROM kernel_integrity;",
       "interval" : 86400,
-      "description" : "Various Linux kernel integrity checked attributes."
+      "description": "Various Linux kernel integrity checked attributes."
     },
     "kernel_modules": {
       "query": "SELECT * FROM kernel_modules;",
@@ -118,19 +123,20 @@
       "snapshot": true
     },
     "last": {
-      "query" : "SELECT * FROM last;",
+      "query": "SELECT * FROM last;",
       "interval" : 3600,
-      "description" : "Retrieves the list of the latest logins with PID, username and timestamp."
+      "description": "Retrieves the list of the latest logins with PID, username and timestamp."
     },
     "ld_preload": {
-      "query" : "SELECT process_envs.pid, process_envs.key, process_envs.value, processes.name, processes.path, processes.cmdline, processes.cwd FROM process_envs join processes USING (pid) WHERE key = 'LD_PRELOAD';",
+      "query": "SELECT process_envs.pid, process_envs.key, process_envs.value, processes.name, processes.path, processes.cmdline, processes.cwd FROM process_envs join processes USING (pid) WHERE key = 'LD_PRELOAD';",
       "interval" : 60,
-      "description" : "Any processes that run with an LD_PRELOAD environment variable"
+      "description": "Any processes that run with an LD_PRELOAD environment variable"
     },
     "ld_so_preload_exists": {
-      "query" : "SELECT * FROM file WHERE path='/etc/ld.so.preload';",
+      "query": "SELECT * FROM file WHERE path='/etc/ld.so.preload';",
       "interval" : 3600,
-      "description" : "Generates an event if ld.so.preload is present - used by rootkits such as Jynx"
+      "description": "Generates an event if ld.so.preload is present - used by rootkits such as Jynx",
+      "snapshot": true
     },
     "memory_info": {
       "query": "SELECT * FROM memory_info;",
@@ -138,21 +144,28 @@
       "description": "Information about memory usage on the system"
     },
     "mounts": {
-      "query" : "SELECT * FROM mounts;",
+      "query": "SELECT device, device_alias,path,type,blocks_size,flags FROM mounts;",
       "interval" : 86400,
-      "description" : "Retrieves the current list of mounted drives in the target system."
+      "description": "Retrieves the current list of mounted drives in the target system."
+    },
+    "network_interfaces_snapshot": {
+      "query" : "SELECT a.interface, a.address, d.mac FROM interface_addresses a JOIN interface_details d USING (interface);",
+      "interval" : 600,
+      "version" : "1.4.5",
+      "description" : "Record the network interfaces and their associated IP and MAC addresses",
+      "snapshot" : true
     },
     "os_version": {
-      "query" : "SELECT * FROM os_version;",
+      "query": "SELECT * FROM os_version;",
       "interval" : 86400,
-      "description" : "Retrieves information from the Operating System where osquery is currently running.",
+      "description": "Retrieves information from the Operating System where osquery is currently running.",
       "snapshot" : true
     },
     "osquery_cpu_pct": {
-      "query" : "SELECT ((osqueryd_time*100)/(SUM(system_time) + SUM(user_time))) AS pct FROM processes, (SELECT (SUM(processes.system_time)+SUM(processes.user_time)) AS osqueryd_time FROM processes WHERE name='osqueryd');",
+      "query": "SELECT ((osqueryd_time*100)/(SUM(system_time) + SUM(user_time))) AS pct FROM processes, (SELECT (SUM(processes.system_time)+SUM(processes.user_time)) AS osqueryd_time FROM processes WHERE name='osqueryd');",
       "interval" : 3600,
-      "version" : "2.0.0",
-      "description" : "The percentage of total CPU time (system+user) consumed by osqueryd",
+      "version": "2.0.0",
+      "description": "The percentage of total CPU time (system+user) consumed by osqueryd",
       "snapshot" : true
     },
     "osquery_info": {
@@ -162,22 +175,22 @@
       "snapshot": true
     },
     "per_query_perf": {
-      "query" : "SELECT name, interval, executions, output_size, wall_time, (user_time/executions) AS avg_user_time, (system_time/executions) AS avg_system_time, average_memory FROM osquery_schedule;",
+      "query": "SELECT name, interval, executions, output_size, wall_time, (user_time/executions) AS avg_user_time, (system_time/executions) AS avg_system_time, average_memory FROM osquery_schedule;",
       "interval" : 1800,
-      "version" : "2.0.0",
-      "description" : "Records the system resources used by each query"
+      "version": "2.0.0",
+      "description": "Records the system resources used by each query"
     },
     "process_rates": {
-      "query" : "SELECT COUNT(1) AS num, count(1)/s AS rate FROM process_events, (SELECT (julianday('now') - 2440587.5)*86400.0 - start_time AS s FROM osquery_info LIMIT 1);",
+      "query": "SELECT COUNT(1) AS num, count(1)/s AS rate FROM process_events, (SELECT (julianday('now') - 2440587.5)*86400.0 - start_time AS s FROM osquery_info LIMIT 1);",
       "interval" : 900,
-      "version" : "2.0.0",
-      "description" : "Records avg rate of process events since daemon started",
+      "version": "2.0.0",
+      "description": "Records avg rate of process events since daemon started",
       "snapshot" : true
     },
     "processes_snapshot": {
-      "query" : "select name, path, cmdline, cwd, on_disk from processes;",
+      "query": "select name, path, cmdline, cwd, on_disk from processes;",
       "interval" : 86400,
-      "description" : "A snapshot of all processes running on the host. Useful for outlier analysis.",
+      "description": "A snapshot of all processes running on the host. Useful for outlier analysis.",
       "snapshot" : true
     },
     "rpm_packages": {
@@ -188,10 +201,10 @@
       "platform": "centos"
     },
     "runtime_perf": {
-      "query" : "SELECT ov.version AS os_version, ov.platform AS os_platform, ov.codename AS os_codename, i.*, p.resident_size, p.user_time, p.system_time, time.minutes AS counter, db.db_size_mb AS database_size from osquery_info i, os_version ov, processes p, time, (SELECT (SUM(size) / 1024) / 1024.0 AS db_size_mb FROM (SELECT value FROM osquery_flags WHERE name = 'database_path' LIMIT 1) flags, file WHERE path LIKE flags.value || '%%' AND type = 'regular') db WHERE p.pid = i.pid;",
+      "query": "SELECT ov.version AS os_version, ov.platform AS os_platform, ov.codename AS os_codename, i.*, p.resident_size, p.user_time, p.system_time, time.minutes AS counter, db.db_size_mb AS database_size from osquery_info i, os_version ov, processes p, time, (SELECT (SUM(size) / 1024) / 1024.0 AS db_size_mb FROM (SELECT value FROM osquery_flags WHERE name = 'database_path' LIMIT 1) flags, file WHERE path LIKE flags.value || '%%' AND type = 'regular') db WHERE p.pid = i.pid;",
       "interval" : 1800,
-      "version" : "2.0.0",
-      "description" : "Records system/user time, db size, and many other system metrics"
+      "version": "2.0.0",
+      "description": "Records system/user time, db size, and many other system metrics"
     },
     "shell_history": {
       "query": "SELECT * FROM users JOIN shell_history USING (uid);",
@@ -199,10 +212,10 @@
       "description": "Record shell history for all users on system (instead of just root)"
     },
     "socket_rates": {
-      "query" : "SELECT COUNT(1) AS num, count(1)/s AS rate FROM socket_events, (SELECT (julianday('now') - 2440587.5)*86400.0 - start_time AS s FROM osquery_info LIMIT 1);",
+      "query": "SELECT COUNT(1) AS num, count(1)/s AS rate FROM socket_events, (SELECT (julianday('now') - 2440587.5)*86400.0 - start_time AS s FROM osquery_info LIMIT 1);",
       "interval" : 900,
-      "version" : "2.0.0",
-      "description" : "Records avg rate of socket events since daemon started",
+      "version": "2.0.0",
+      "description": "Records avg rate of socket events since daemon started",
       "snapshot" : true
     },
     "suid_bin": {
@@ -217,24 +230,24 @@
       "snapshot": true
     },
     "usb_devices": {
-      "query" : "SELECT * FROM usb_devices;",
+      "query": "SELECT * FROM usb_devices;",
       "interval" : 120,
-      "description" : "Retrieves the current list of USB devices in the target system."
+      "description": "Retrieves the current list of USB devices in the target system."
     },
     "user_ssh_keys": {
-      "query" : "SELECT * FROM users JOIN user_ssh_keys USING (uid);",
+      "query": "SELECT * FROM users JOIN user_ssh_keys USING (uid);",
       "interval" : 86400,
-      "description" : "Returns the private keys in the users ~/.ssh directory and whether or not they are encrypted"
+      "description": "Returns the private keys in the users ~/.ssh directory and whether or not they are encrypted"
     },
     "users": {
-      "query" : "SELECT * FROM users;",
+      "query": "SELECT * FROM users;",
       "interval" : 86400,
-      "description" : "Local system users."
+      "description": "Local system users."
     },
     "users_snapshot": {
-      "query" : "SELECT * FROM users;",
+      "query": "SELECT * FROM users;",
       "interval" : 86400,
-      "description" : "Local system users.",
+      "description": "Local system users.",
       "snapshot": true
     }
   },
@@ -242,6 +255,7 @@
     "configuration": [
       "/etc/passwd",
       "/etc/shadow",
+      "/etc/ld.so.conf",
       "/etc/ld.so.conf.d/%%",
       "/etc/pam.d/%%",
       "/etc/resolv.conf",


### PR DESCRIPTION
- Addresses issue #5 (Standardize pack and naming convention)
- Adds rc.common monitoring for MacOS
- Adds a query for the windows_crashes table
- Adds checks for two persistence techniques to the windows-registry-monitoring pack
- Removed osquery-native packs to ensure users get the most up-to-date versions