### PR TITLE
June 2019 Update

### DIFF
--- a/Classic/Endpoints/MacOS/osquery.conf
+++ b/Classic/Endpoints/MacOS/osquery.conf
@@ -6,7 +6,7 @@
   "platform": "darwin",
   "schedule": {
     "authorized_keys": {
-      "query": "SELECT * FROM users JOIN authorized_keys USING (uid);",
+      "query": "SELECT * FROM users CROSS JOIN authorized_keys USING (uid);",
       "interval": 28800,
       "description": "List authorized_keys for each user on the system"
     },
@@ -16,17 +16,17 @@
       "description": "MD5 hash of boot.efi"
     },
     "browser_plugins": {
-      "query": "SELECT * FROM users JOIN browser_plugins USING (uid);",
+      "query": "SELECT * FROM users CROSS JOIN browser_plugins USING (uid);",
       "interval": 3600,
       "description": "All C/NPAPI browser plugin details for all users."
     },
     "chrome_extensions": {
-      "query": "SELECT * FROM users JOIN chrome_extensions USING (uid);",
+      "query": "SELECT * FROM users CROSS JOIN chrome_extensions USING (uid);",
       "interval": 3600,
       "description": "List installed Chrome Extensions for all users"
     },
     "chrome_extensions_snapshot": {
-      "query": "SELECT * FROM users JOIN chrome_extensions USING (uid);",
+      "query": "SELECT * FROM users CROSS JOIN chrome_extensions USING (uid);",
       "interval": 28800,
       "description": "Snapshot query for Chrome extensions"
     },
@@ -41,13 +41,14 @@
       "interval": 3600,
       "description": "Line parsed values from system and user cron/tab."
     },
-    "disk_encryption": {
+    "disk_encryption_snapshot": {
       "query": "SELECT * FROM disk_encryption;",
       "interval": 28800,
-      "description": "Disk encryption status and information."
+      "description": "Disk encryption status and information.",
+      "snapshot": true
     },
     "disk_free_space_pct": {
-      "query": "SELECT (blocks_available * 100 / blocks) AS pct FROM mounts WHERE device='/dev/disk1';",
+      "query": "SELECT (blocks_available * 100 / blocks) AS pct FROM mounts WHERE device='/dev/disk1s1';",
       "interval": 3600,
       "description": "Displays the percentage of free space available on the primary disk partition",
       "snapshot": true
@@ -75,7 +76,7 @@
       "description": "List the contents of /etc/hosts"
     },
     "event_taps": {
-      "query": "SELECT * FROM event_taps INNER JOIN processes ON event_taps.tapping_process = processes.pid WHERE event_tapped NOT LIKE '%mouse%' AND processes.path NOT LIKE '%.app%' AND processes.path!='/Library/Application Support/org.pqrs/Karabiner-Elements/bin/karabiner_grabber' AND processes.path NOT LIKE '/Users/%/bin/kwm' AND processes.path!='/Library/Rapport/bin/rooksd' AND processes.path!='/usr/sbin/universalaccessd' AND processes.path NOT LIKE '/usr/local/Cellar/%' AND  processes.path NOT LIKE '/System/Library/%' AND processes.path NOT LIKE '%/steamapps/%' AND event_taps.enabled=1;",
+      "query": "SELECT * FROM event_taps INNER JOIN processes ON event_taps.tapping_process = processes.pid WHERE event_tapped NOT LIKE '%mouse%' AND processes.path NOT IN ('/usr/libexec/airportd', '/usr/sbin/universalaccessd') AND processes.path NOT LIKE '/System/Library/%' AND processes.path NOT LIKE '%/steamapps/%' AND processes.path NOT LIKE '%.app%' AND event_taps.enabled=1;",
       "interval": 300,
       "description": "Returns information about installed event taps. Can be used to detect keyloggers"
     },
@@ -86,7 +87,7 @@
       "description": "Track time/action changes to files specified in configuration data."
     },
     "firefox_addons": {
-      "query": "SELECT * FROM users JOIN firefox_addons USING (uid);",
+      "query": "SELECT * FROM users CROSS JOIN firefox_addons USING (uid);",
       "interval": 3600,
       "description": "List installed Firefox addons for all users"
     },
@@ -227,7 +228,7 @@
       "snapshot": true
     },
     "safari_extensions": {
-      "query": "SELECT * FROM users JOIN safari_extensions USING (uid);",
+      "query": "SELECT * FROM users CROSS JOIN safari_extensions USING (uid);",
       "interval": 3600,
       "description": "Safari browser extension details for all users."
     },
@@ -273,6 +274,12 @@
       "query": "SELECT * FROM users;",
       "interval": 28800,
       "description": "Local system users."
+    },
+    "wifi_status_snapshot": {
+      "query": "SELECT * FROM wifi_status;",
+      "interval": 28800,
+      "description": "Shows information about the wifi network that a host is currently connected to.",
+      "snapshot": true
     },
     "wireless_networks": {
       "query": "SELECT ssid, network_name, security_type, last_connected, captive_portal, possibly_hidden, roaming, roaming_profile FROM wifi_networks;",

--- a/Classic/Endpoints/Windows/osquery.conf
+++ b/Classic/Endpoints/Windows/osquery.conf
@@ -5,14 +5,24 @@
   },
   "platform": "windows",
   "schedule": {
+    "appcompat_shims": {
+      "query": "SELECT * FROM appcompat_shims WHERE description!='EMET_Database' AND executable NOT IN ('setuphost.exe','setupprep.exe','iisexpress.exe');",
+      "interval": 3600,
+      "description": "Appcompat shims (.sdb files) installed on Windows hosts."
+    },
+    "bitlocker_info_snapshot": {
+      "query": "SELECT * FROM bitlocker_info;",
+      "interval": 28800,
+      "description": "Disk encryption status and information snapshot query."
+    },
     "certificates": {
-      "query": "SELECT * FROM certificates WHERE path != 'Other People';",
+      "query": "SELECT * FROM certificates WHERE path!='Other People';",
       "interval": 3600,
       "description": "List all certificates in the trust store",
       "removed": false
     },
     "certificates_snapshot": {
-      "query": "SELECT * FROM certificates WHERE path != 'Other People';",
+      "query": "SELECT * FROM certificates WHERE path!='Other People';",
       "interval": 28800,
       "description": "List all certificates in the trust store (snapshot query)",
       "snapshot": true
@@ -23,12 +33,12 @@
       "description": "List installed Chocolatey packages"
     },
     "chrome_extensions": {
-      "query": "SELECT * FROM users JOIN chrome_extensions USING (uid);",
+      "query": "SELECT * FROM users CROSS JOIN chrome_extensions USING (uid);",
       "interval": 3600,
       "description": "List installed Chrome Extensions for all users"
     },
     "chrome_extensions_snapshot": {
-      "query": "SELECT * FROM users JOIN chrome_extensions USING (uid);",
+      "query": "SELECT * FROM users CROSS JOIN chrome_extensions USING (uid);",
       "interval": 28800,
       "description": "Snapshot query for Chrome extensions"
     },

--- a/Classic/Servers/Linux/osquery.conf
+++ b/Classic/Servers/Linux/osquery.conf
@@ -21,15 +21,22 @@
       "description": "File events collected from file integrity monitoring",
       "removed":false
     },
+    "apt_sources": {
+      "query": "SELECT * FROM apt_sources;",
+      "interval": 86400,
+      "description": "Display apt package manager sources.",
+      "snapshot": true,
+      "platform": "ubuntu"
+    },
     "authorized_keys": {
-      "query": "SELECT * FROM users JOIN authorized_keys USING (uid);",
-      "interval" : 86400,
+      "query": "SELECT * FROM users CROSS JOIN authorized_keys USING (uid);",
+      "interval": 86400,
       "description": "A line-delimited authorized_keys table."
     },
     "behavioral_reverse_shell": {
-      "query" : "SELECT DISTINCT(processes.pid), processes.parent, processes.name, processes.path, processes.cmdline, processes.cwd, processes.root, processes.uid, processes.gid, processes.start_time, process_open_sockets.remote_address, process_open_sockets.remote_port, (SELECT cmdline FROM processes AS parent_cmdline WHERE pid=processes.parent) AS parent_cmdline FROM processes JOIN process_open_sockets USING (pid) LEFT OUTER JOIN process_open_files ON processes.pid = process_open_files.pid WHERE (name='sh' OR name='bash') AND remote_address NOT IN ('0.0.0.0', '::', '') AND remote_address NOT LIKE '10.%' AND remote_address NOT LIKE '192.168.%';",
-      "interval" : 600,
-      "description" : "Find shell processes that have open sockets"
+      "query": "SELECT DISTINCT(processes.pid), processes.parent, processes.name, processes.path, processes.cmdline, processes.cwd, processes.root, processes.uid, processes.gid, processes.start_time, process_open_sockets.remote_address, process_open_sockets.remote_port, (SELECT cmdline FROM processes AS parent_cmdline WHERE pid=processes.parent) AS parent_cmdline FROM processes JOIN process_open_sockets USING (pid) LEFT OUTER JOIN process_open_files ON processes.pid = process_open_files.pid WHERE (name='sh' OR name='bash') AND remote_address NOT IN ('0.0.0.0', '::', '') AND remote_address NOT LIKE '10.%' AND remote_address NOT LIKE '192.168.%';",
+      "interval": 600,
+      "description": "Find shell processes that have open sockets"
     },
     "cpu_time": {
       "query": "SELECT * FROM cpu_time;",
@@ -38,12 +45,12 @@
     },
     "crontab": {
       "query": "SELECT * FROM crontab;",
-      "interval" : 3600,
+      "interval": 3600,
       "description": "Retrieves all the jobs scheduled in crontab in the target system."
     },
     "crontab_snapshot": {
       "query": "SELECT * FROM crontab;",
-      "interval" : 86400,
+      "interval": 86400,
       "description": "Retrieves all the jobs scheduled in crontab in the target system.",
       "snapshot": true
     },
@@ -51,7 +58,7 @@
       "query": "SELECT * FROM deb_packages;",
       "interval": 86400,
       "description": "Display all installed DEB packages",
-      "snapshot" : true,
+      "snapshot": true,
       "platform": "ubuntu"
     },
     "dns_resolvers": {
@@ -61,36 +68,36 @@
     },
     "ec2_instance_metadata": {
       "query": "SELECT * FROM ec2_instance_metadata;",
-      "interval" : 3600,
+      "interval": 3600,
       "description": "Retrieve the EC2 metadata for this endpoint"
     },
     "ec2_instance_metadata_snapshot": {
       "query": "SELECT * FROM ec2_instance_metadata;",
-      "interval" : 86400,
+      "interval": 86400,
       "description": "Snapshot query to retrieve the EC2 metadata for this endpoint",
-      "snapshot" : true
+      "snapshot": true
     },
     "ec2_instance_tags": {
       "query": "SELECT * FROM ec2_instance_tags;",
-      "interval" : 3600,
+      "interval": 3600,
       "description": "Retrieve the EC2 tags for this endpoint"
     },
     "ec2_instance_tags_snapshot": {
       "query": "SELECT * FROM ec2_instance_tags;",
-      "interval" : 86400,
+      "interval": 86400,
       "description": "Snapshot query to retrieve the EC2 tags for this instance",
-      "snapshot" : true
+      "snapshot": true
     },
     "etc_hosts": {
       "query": "SELECT * FROM etc_hosts;",
-      "interval" : 86400,
+      "interval": 3600,
       "description": "Retrieves all the entries in the target system /etc/hosts file."
     },
     "etc_hosts_snapshot": {
       "query": "SELECT * FROM etc_hosts;",
-      "interval" : 86400,
+      "interval": 86400,
       "description": "Retrieves all the entries in the target system /etc/hosts file.",
-      "snapshot" : true
+      "snapshot": true
     },
     "hardware_events": {
       "query": "SELECT * FROM hardware_events;",
@@ -99,19 +106,19 @@
     },
     "iptables": {
       "query": "SELECT * FROM iptables;",
-      "interval" : 86400,
+      "interval": 86400,
       "platform": "linux",
       "description": "Retrieves the current filters and chains per filter in the target system."
     },
     "kernel_info": {
       "query": "SELECT * FROM kernel_info;",
-      "interval" : 86400,
+      "interval": 86400,
       "description": "Retrieves information from the current kernel in the target system.",
-      "snapshot" : true
+      "snapshot": true
     },
     "kernel_integrity": {
       "query": "SELECT * FROM kernel_integrity;",
-      "interval" : 86400,
+      "interval": 86400,
       "description": "Various Linux kernel integrity checked attributes."
     },
     "kernel_modules": {
@@ -127,18 +134,25 @@
     },
     "last": {
       "query": "SELECT * FROM last;",
-      "interval" : 3600,
+      "interval": 3600,
       "description": "Retrieves the list of the latest logins with PID, username and timestamp."
     },
     "ld_preload": {
       "query": "SELECT process_envs.pid, process_envs.key, process_envs.value, processes.name, processes.path, processes.cmdline, processes.cwd FROM process_envs join processes USING (pid) WHERE key = 'LD_PRELOAD';",
-      "interval" : 60,
-      "description": "Any processes that run with an LD_PRELOAD environment variable"
+      "interval": 60,
+      "description": "Any processes that run with an LD_PRELOAD environment variable",
+      "snapshot": true
     },
     "ld_so_preload_exists": {
       "query": "SELECT * FROM file WHERE path='/etc/ld.so.preload' AND path!='';",
-      "interval" : 3600,
+      "interval": 3600,
       "description": "Generates an event if ld.so.preload is present - used by rootkits such as Jynx",
+      "snapshot": true
+    },
+    "listening_ports": {
+      "query": "SELECT pid, port, processes.path, cmdline, cwd FROM listening_ports JOIN processes USING (pid) WHERE port!=0;",
+      "interval": 86400,
+      "description": "Gather information about processes that are listening on a socket.",
       "snapshot": true
     },
     "memory_info": {
@@ -148,26 +162,20 @@
     },
     "mounts": {
       "query": "SELECT device, device_alias, path, type, blocks_size, flags FROM mounts;",
-      "interval" : 86400,
+      "interval": 86400,
       "description": "Retrieves the current list of mounted drives in the target system."
     },
     "network_interfaces_snapshot": {
       "query": "SELECT a.interface, a.address, d.mac FROM interface_addresses a JOIN interface_details d USING (interface);",
-      "interval" : 600,
+      "interval": 600,
       "description": "Record the network interfaces and their associated IP and MAC addresses",
-      "snapshot" : true
+      "snapshot": true
     },
     "os_version": {
       "query": "SELECT * FROM os_version;",
-      "interval" : 86400,
+      "interval": 86400,
       "description": "Retrieves information from the Operating System where osquery is currently running.",
-      "snapshot" : true
-    },
-    "osquery_cpu_pct": {
-      "query": "SELECT ((osqueryd_time*100)/(SUM(system_time) + SUM(user_time))) AS pct FROM processes, (SELECT (SUM(processes.system_time)+SUM(processes.user_time)) AS osqueryd_time FROM processes WHERE name='osqueryd');",
-      "interval" : 3600,
-      "description": "The percentage of total CPU time (system+user) consumed by osqueryd",
-      "snapshot" : true
+      "snapshot": true
     },
     "osquery_info": {
       "query": "SELECT * FROM osquery_info;",
@@ -175,22 +183,11 @@
       "description": "Information about the running osquery configuration",
       "snapshot": true
     },
-    "per_query_perf": {
-      "query": "SELECT name, interval, executions, output_size, wall_time, (user_time/executions) AS avg_user_time, (system_time/executions) AS avg_system_time, average_memory FROM osquery_schedule;",
-      "interval" : 1800,
-      "description": "Records the system resources used by each query"
-    },
-    "process_rates": {
-      "query": "SELECT COUNT(1) AS num, count(1)/s AS rate FROM process_events, (SELECT (julianday('now') - 2440587.5)*86400.0 - start_time AS s FROM osquery_info LIMIT 1);",
-      "interval" : 900,
-      "description": "Records avg rate of process events since daemon started",
-      "snapshot" : true
-    },
     "processes_snapshot": {
       "query": "select name, path, cmdline, cwd, on_disk from processes;",
-      "interval" : 86400,
+      "interval": 86400,
       "description": "A snapshot of all processes running on the host. Useful for outlier analysis.",
-      "snapshot" : true
+      "snapshot": true
     },
     "rpm_packages": {
       "query": "SELECT name, version, release, arch FROM rpm_packages;",
@@ -201,19 +198,13 @@
     },
     "runtime_perf": {
       "query": "SELECT ov.version AS os_version, ov.platform AS os_platform, ov.codename AS os_codename, i.*, p.resident_size, p.user_time, p.system_time, time.minutes AS counter, db.db_size_mb AS database_size from osquery_info i, os_version ov, processes p, time, (SELECT (SUM(size) / 1024) / 1024.0 AS db_size_mb FROM (SELECT value FROM osquery_flags WHERE name = 'database_path' LIMIT 1) flags, file WHERE path LIKE flags.value || '%%' AND type = 'regular') db WHERE p.pid = i.pid;",
-      "interval" : 1800,
+      "interval": 1800,
       "description": "Records system/user time, db size, and many other system metrics"
     },
     "shell_history": {
-      "query": "SELECT * FROM users JOIN shell_history USING (uid);",
+      "query": "SELECT * FROM users CROSS JOIN shell_history USING (uid);",
       "interval": 3600,
       "description": "Record shell history for all users on system (instead of just root)"
-    },
-    "socket_rates": {
-      "query": "SELECT COUNT(1) AS num, count(1)/s AS rate FROM socket_events, (SELECT (julianday('now') - 2440587.5)*86400.0 - start_time AS s FROM osquery_info LIMIT 1);",
-      "interval" : 900,
-      "description": "Records avg rate of socket events since daemon started",
-      "snapshot" : true
     },
     "suid_bin": {
       "query": "SELECT * FROM suid_bin;",
@@ -228,30 +219,38 @@
     },
     "usb_devices": {
       "query": "SELECT * FROM usb_devices;",
-      "interval" : 120,
+      "interval": 120,
       "description": "Retrieves the current list of USB devices in the target system."
     },
     "user_ssh_keys": {
-      "query": "SELECT * FROM users JOIN user_ssh_keys USING (uid);",
-      "interval" : 86400,
+      "query": "SELECT * FROM users CROSS JOIN user_ssh_keys USING (uid);",
+      "interval": 86400,
       "description": "Returns the private keys in the users ~/.ssh directory and whether or not they are encrypted"
     },
     "users": {
       "query": "SELECT * FROM users;",
-      "interval" : 86400,
+      "interval": 86400,
       "description": "Local system users."
     },
     "users_snapshot": {
       "query": "SELECT * FROM users;",
-      "interval" : 86400,
+      "interval": 86400,
       "description": "Local system users.",
       "snapshot": true
+    },
+    "yum_sources": {
+      "query": "SELECT name, baseurl, enabled, gpgcheck FROM yum_sources;",
+      "interval": 86400,
+      "description": "Display yum package manager sources",
+      "snapshot": true,
+      "platform": "centos"
     }
   },
   "file_paths": {
     "configuration": [
       "/etc/passwd",
       "/etc/shadow",
+      "/etc/ld.so.preload",
       "/etc/ld.so.conf",
       "/etc/ld.so.conf.d/%%",
       "/etc/pam.d/%%",

--- a/Fleet/Endpoints/MacOS/osquery.yaml
+++ b/Fleet/Endpoints/MacOS/osquery.yaml
@@ -239,9 +239,10 @@ spec:
     query: chrome_extensions
   - description: Disk encryption status and information.
     interval: 3600
-    name: disk_encryption
+    name: disk_encryption_snapshot
     platform: darwin
-    query: disk_encryption
+    query: disk_encryption_snapshot
+    snapshot: true
   - description: Local system users.
     interval: 28800
     name: users_snapshot
@@ -282,6 +283,12 @@ spec:
     name: sip_config
     platform: darwin
     query: sip_config
+  - description: Shows information about the wifi network that a host is currently connected to.
+    interval: 28800
+    name: wifi_status_snapshot
+    platform: darwin
+    query: wifi_status_snapshot
+    snapshot: true
   - description: Returns the private keys in the users ~/.ssh directory and whether
       or not they are encrypted.
     interval: 3600
@@ -365,13 +372,10 @@ spec:
   description: Returns information about installed event taps. Can be used to detect
     keyloggers
   name: event_taps
-  query: SELECT * FROM event_taps INNER JOIN processes ON event_taps.tapping_process
-    = processes.pid WHERE event_tapped NOT LIKE '%mouse%' AND processes.path NOT LIKE
-    '%.app%' AND processes.path!='/Library/Application Support/org.pqrs/Karabiner-Elements/bin/karabiner_grabber'
-    AND processes.path NOT LIKE '/Users/%/bin/kwm' AND processes.path!='/Library/Rapport/bin/rooksd'
-    AND processes.path!='/usr/sbin/universalaccessd' AND processes.path NOT LIKE '/usr/local/Cellar/%'
-    AND  processes.path NOT LIKE '/System/Library/%' AND processes.path NOT LIKE '%/steamapps/%'
-    AND event_taps.enabled=1;
+  query: SELECT * FROM event_taps INNER JOIN processes ON event_taps.tapping_process = processes.pid
+    WHERE event_tapped NOT LIKE '%mouse%' AND processes.path NOT IN ('/usr/libexec/airportd',
+    '/usr/sbin/universalaccessd') AND processes.path NOT LIKE '/System/Library/%' AND processes.path
+    NOT LIKE '%/steamapps/%' AND processes.path NOT LIKE '%.app%' AND event_taps.enabled=1;
 ---
 apiVersion: v1
 kind: query
@@ -456,6 +460,13 @@ spec:
 apiVersion: v1
 kind: query
 spec:
+  description: Shows information about the wifi network that a host is currently connected to.
+  name: wifi_status_snapshot
+  query: SELECT * FROM wifi_status;
+---
+apiVersion: v1
+kind: query
+spec:
   description: Snapshot query for macosx_kextstat
   name: macosx_kextstat_snapshot
   query: SELECT kernel_extensions.name, kernel_extensions.version, kernel_extensions.path,
@@ -479,7 +490,7 @@ kind: query
 spec:
   description: Safari browser extension details for all users.
   name: safari_extensions
-  query: SELECT * FROM users JOIN safari_extensions USING (uid);
+  query: SELECT * FROM users CROSS JOIN safari_extensions USING (uid);
 ---
 apiVersion: v1
 kind: query
@@ -500,7 +511,7 @@ kind: query
 spec:
   description: List authorized_keys for each user on the system
   name: authorized_keys
-  query: SELECT * FROM users JOIN authorized_keys USING (uid);
+  query: SELECT * FROM users CROSS JOIN authorized_keys USING (uid);
 ---
 apiVersion: v1
 kind: query
@@ -508,7 +519,7 @@ spec:
   description: Application, System, and Mobile App crash logs.
   name: crashes
   query: SELECT uid, datetime, responsible, exception_type, identifier, version, crash_path
-    FROM users JOIN crashes USING (uid);
+    FROM users CROSS JOIN crashes USING (uid);
 ---
 apiVersion: v1
 kind: query
@@ -516,7 +527,7 @@ spec:
   description: Displays the percentage of free space available on the primary disk
     partition
   name: disk_free_space_pct
-  query: SELECT (blocks_available * 100 / blocks) AS pct FROM mounts WHERE device='/dev/disk1';
+  query: SELECT (blocks_available * 100 / blocks) AS pct FROM mounts WHERE device='/dev/disk1s1';
 ---
 apiVersion: v1
 kind: query
@@ -553,7 +564,7 @@ kind: query
 spec:
   description: Snapshot query for Chrome extensions
   name: chrome_extensions_snapshot
-  query: SELECT * FROM users JOIN chrome_extensions USING (uid);
+  query: SELECT * FROM users CROSS JOIN chrome_extensions USING (uid);
 ---
 apiVersion: v1
 kind: query
@@ -589,14 +600,14 @@ kind: query
 spec:
   description: All C/NPAPI browser plugin details for all users.
   name: browser_plugins
-  query: SELECT * FROM users JOIN browser_plugins USING (uid);
+  query: SELECT * FROM users CROSS JOIN browser_plugins USING (uid);
 ---
 apiVersion: v1
 kind: query
 spec:
   description: List installed Firefox addons for all users
   name: firefox_addons
-  query: SELECT * FROM users JOIN firefox_addons USING (uid);
+  query: SELECT * FROM users CROSS JOIN firefox_addons USING (uid);
 ---
 apiVersion: v1
 kind: query
@@ -625,13 +636,13 @@ kind: query
 spec:
   description: List installed Chrome Extensions for all users
   name: chrome_extensions
-  query: SELECT * FROM users JOIN chrome_extensions USING (uid);
+  query: SELECT * FROM users CROSS JOIN chrome_extensions USING (uid);
 ---
 apiVersion: v1
 kind: query
 spec:
   description: Disk encryption status and information.
-  name: disk_encryption
+  name: disk_encryption_snapshot
   query: SELECT * FROM disk_encryption;
 ---
 apiVersion: v1
@@ -691,4 +702,4 @@ spec:
   description: Returns the private keys in the users ~/.ssh directory and whether
     or not they are encrypted.
   name: user_ssh_keys
-  query: SELECT * FROM users JOIN user_ssh_keys USING (uid);
+  query: SELECT * FROM users CROSS JOIN user_ssh_keys USING (uid);

--- a/Fleet/Endpoints/Windows/osquery.yaml
+++ b/Fleet/Endpoints/Windows/osquery.yaml
@@ -227,8 +227,34 @@ spec:
     platform: windows
     query: scheduled_tasks_snapshot
     snapshot: true
+  - description: Appcompat shims (.sdb files) installed on Windows hosts.
+    interval: 3600
+    name: appcompat_shims
+    platform: windows
+    query: appcompat_shims
+  - description: Disk encryption status and information snapshot query.
+    interval: 28800
+    name: bitlocker_info_snapshot
+    platform: windows
+    query: bitlocker_info_snapshot
+    snapshot: true
   targets:
     labels: null
+---
+apiVersion: v1
+kind: query
+spec:
+  description: Appcompat shims (.sdb files) installed on Windows hosts.
+  name: appcompat_shims
+  query: SELECT * FROM appcompat_shims WHERE description!='EMET_Database' AND
+    executable NOT IN ('setuphost.exe','setupprep.exe','iisexpress.exe');
+---
+apiVersion: v1
+kind: query
+spec:
+  description: Disk encryption status and information snapshot query.
+  name: bitlocker_info_snapshot
+  query: SELECT * FROM bitlocker_info;
 ---
 apiVersion: v1
 kind: query
@@ -302,7 +328,7 @@ kind: query
 spec:
   description: Snapshot query for Chrome extensions
   name: chrome_extensions_snapshot
-  query: SELECT * FROM users JOIN chrome_extensions USING (uid);
+  query: SELECT * FROM users CROSS JOIN chrome_extensions USING (uid);
 ---
 apiVersion: v1
 kind: query
@@ -466,7 +492,7 @@ kind: query
 spec:
   description: List installed Chrome Extensions for all users
   name: chrome_extensions
-  query: SELECT * FROM users JOIN chrome_extensions USING (uid);
+  query: SELECT * FROM users CROSS JOIN chrome_extensions USING (uid);
 ---
 apiVersion: v1
 kind: query

--- a/Fleet/Servers/Linux/osquery.yaml
+++ b/Fleet/Servers/Linux/osquery.yaml
@@ -5,252 +5,247 @@ spec:
   name: LinuxPack
   queries:
   - description: Retrieves all the jobs scheduled in crontab in the target system.
-    interval: 0
+    interval: 86400
     name: crontab_snapshot
     platform: linux
     query: crontab_snapshot
     snapshot: true
   - description: Various Linux kernel integrity checked attributes.
-    interval: 0
+    interval: 86400
     name: kernel_integrity
     platform: linux
     query: kernel_integrity
   - description: Linux kernel modules both loaded and within the load search path.
-    interval: 0
+    interval: 3600
     name: kernel_modules
     platform: linux
     query: kernel_modules
   - description: Retrieves the current list of mounted drives in the target system.
-    interval: 0
+    interval: 86400
     name: mounts
     platform: linux
     query: mounts
-  - description: The percentage of total CPU time (system+user) consumed by osqueryd
-    interval: 0
-    name: osquery_cpu_pct
-    platform: linux
-    query: osquery_cpu_pct
-    snapshot: true
   - description: Socket events collected from the audit framework
-    interval: 0
+    interval: 10
     name: socket_events
     platform: linux
     query: socket_events
   - description: Record the network interfaces and their associated IP and MAC addresses
-    interval: 0
+    interval: 600
     name: network_interfaces_snapshot
     platform: linux
     query: network_interfaces_snapshot
     snapshot: true
-    version: 1.4.5
   - description: Information about the running osquery configuration
-    interval: 0
+    interval: 86400
     name: osquery_info
     platform: linux
     query: osquery_info
     snapshot: true
   - description: Display all installed RPM packages
-    interval: 0
+    interval: 86400
     name: rpm_packages
     platform: centos
     query: rpm_packages
     snapshot: true
   - description: Record shell history for all users on system (instead of just root)
-    interval: 0
+    interval: 3600
     name: shell_history
     platform: linux
     query: shell_history
   - description: File events collected from file integrity monitoring
-    interval: 0
+    interval: 10
     name: file_events
     platform: linux
     query: file_events
     removed: false
   - description: Retrieve the EC2 metadata for this endpoint
-    interval: 0
+    interval: 3600
     name: ec2_instance_metadata
     platform: linux
     query: ec2_instance_metadata
   - description: Retrieve the EC2 tags for this endpoint
-    interval: 0
+    interval: 3600
     name: ec2_instance_tags
     platform: linux
     query: ec2_instance_tags
   - description: Snapshot query to retrieve the EC2 tags for this instance
-    interval: 0
+    interval: 86400
     name: ec2_instance_tags_snapshot
     platform: linux
     query: ec2_instance_tags_snapshot
     snapshot: true
   - description: Retrieves the current filters and chains per filter in the target
       system.
-    interval: 0
+    interval: 86400
     name: iptables
     platform: linux
     query: iptables
   - description: Display any SUID binaries that are owned by root
-    interval: 0
+    interval: 86400
     name: suid_bin
     platform: linux
     query: suid_bin
   - description: Display all installed DEB packages
-    interval: 0
+    interval: 86400
     name: deb_packages
     platform: ubuntu
     query: deb_packages
     snapshot: true
   - description: Find shell processes that have open sockets
-    interval: 0
+    interval: 600
     name: behavioral_reverse_shell
     platform: linux
     query: behavioral_reverse_shell
   - description: Retrieves all the jobs scheduled in crontab in the target system.
-    interval: 0
+    interval: 3600
     name: crontab
     platform: linux
     query: crontab
-  - description: Records the system resources used by each query
-    interval: 0
-    name: per_query_perf
-    platform: linux
-    query: per_query_perf
-  - description: Records avg rate of socket events since daemon started
-    interval: 0
-    name: socket_rates
-    platform: linux
-    query: socket_rates
-    snapshot: true
   - description: Local system users.
-    interval: 0
+    interval: 86400
     name: users
     platform: linux
     query: users
   - description: Process events collected from the audit framework
-    interval: 0
+    interval: 10
     name: process_events
     platform: linux
     query: process_events
   - description: Retrieves the list of the latest logins with PID, username and timestamp.
-    interval: 0
+    interval: 3600
     name: last
     platform: linux
     query: last
   - description: Any processes that run with an LD_PRELOAD environment variable
-    interval: 0
+    interval: 60
     name: ld_preload
     platform: linux
     query: ld_preload
-  - description: Records avg rate of process events since daemon started
-    interval: 0
-    name: process_rates
-    platform: linux
-    query: process_rates
     snapshot: true
   - description: Information about the system hardware and name
-    interval: 0
+    interval: 86400
     name: system_info
     platform: linux
     query: system_info
     snapshot: true
   - description: Returns the private keys in the users ~/.ssh directory and whether
       or not they are encrypted
-    interval: 0
+    interval: 86400
     name: user_ssh_keys
     platform: linux
     query: user_ssh_keys
   - description: Local system users.
-    interval: 0
+    interval: 86400
     name: users_snapshot
     platform: linux
     query: users_snapshot
     snapshot: true
   - description: DNS resolvers used by the host
-    interval: 0
+    interval: 3600
     name: dns_resolvers
     platform: linux
     query: dns_resolvers
   - description: Retrieves information from the current kernel in the target system.
-    interval: 0
+    interval: 86400
     name: kernel_info
     platform: linux
     query: kernel_info
     snapshot: true
   - description: Linux kernel modules both loaded and within the load search path.
-    interval: 0
+    interval: 86400
     name: kernel_modules_snapshot
     platform: linux
     query: kernel_modules_snapshot
     snapshot: true
   - description: Generates an event if ld.so.preload is present - used by rootkits
       such as Jynx
-    interval: 0
+    interval: 3600
     name: ld_so_preload_exists
     platform: linux
     query: ld_so_preload_exists
     snapshot: true
   - description: Records system/user time, db size, and many other system metrics
-    interval: 0
+    interval: 1800
     name: runtime_perf
     platform: linux
     query: runtime_perf
   - description: Retrieves all the entries in the target system /etc/hosts file.
-    interval: 0
+    interval: 86400
     name: etc_hosts_snapshot
     platform: linux
     query: etc_hosts_snapshot
     snapshot: true
   - description: Snapshot query to retrieve the EC2 metadata for this endpoint
-    interval: 0
+    interval: 86400
     name: ec2_instance_metadata_snapshot
     platform: linux
     query: ec2_instance_metadata_snapshot
     snapshot: true
   - description: ""
-    interval: 0
+    interval: 10
     name: hardware_events
     platform: linux
     query: hardware_events
     removed: false
   - description: Information about memory usage on the system
-    interval: 0
+    interval: 3600
     name: memory_info
     platform: linux
     query: memory_info
   - description: Displays information from /proc/stat file about the time the CPU
       cores spent in different parts of the system
-    interval: 0
+    interval: 3600
     name: cpu_time
     platform: linux
     query: cpu_time
   - description: Retrieves all the entries in the target system /etc/hosts file.
-    interval: 0
+    interval: 3600
     name: etc_hosts
     platform: linux
     query: etc_hosts
   - description: Retrieves information from the Operating System where osquery is
       currently running.
-    interval: 0
+    interval: 86400
     name: os_version
     platform: linux
     query: os_version
     snapshot: true
   - description: A snapshot of all processes running on the host. Useful for outlier
       analysis.
-    interval: 0
+    interval: 86400
     name: processes_snapshot
     platform: linux
     query: processes_snapshot
     snapshot: true
   - description: Retrieves the current list of USB devices in the target system.
-    interval: 0
+    interval: 120
     name: usb_devices
     platform: linux
     query: usb_devices
   - description: A line-delimited authorized_keys table.
-    interval: 0
+    interval: 86400
     name: authorized_keys
     platform: linux
     query: authorized_keys
+  - description: Display apt package manager sources.
+    interval: 86400
+    name: apt_sources
+    platform: ubuntu
+    query: apt_sources
+    snapshot: true
+  - description: Gather information about processes that are listening on a socket.
+    interval: 86400
+    name: listening_ports
+    platform: linux
+    query: listening_ports
+    snapshot: true
+  - description: Display yum package manager sources.
+    interval: 86400
+    name: yum_sources
+    platform: centos
+    query: yum_sources
+    snapshot: true
   targets:
     labels: null
 ---
@@ -281,15 +276,6 @@ spec:
   description: Retrieves the current list of mounted drives in the target system.
   name: mounts
   query: SELECT device, device_alias, path, type, blocks_size, flags FROM mounts;
----
-apiVersion: v1
-kind: query
-spec:
-  description: The percentage of total CPU time (system+user) consumed by osqueryd
-  name: osquery_cpu_pct
-  query: SELECT ((osqueryd_time*100)/(SUM(system_time) + SUM(user_time))) AS pct FROM
-    processes, (SELECT (SUM(processes.system_time)+SUM(processes.user_time)) AS osqueryd_time
-    FROM processes WHERE name='osqueryd');
 ---
 apiVersion: v1
 kind: query
@@ -329,7 +315,7 @@ kind: query
 spec:
   description: Record shell history for all users on system (instead of just root)
   name: shell_history
-  query: SELECT * FROM users JOIN shell_history USING (uid);
+  query: SELECT * FROM users CROSS JOIN shell_history USING (uid);
 ---
 apiVersion: v1
 kind: query
@@ -404,23 +390,6 @@ spec:
 apiVersion: v1
 kind: query
 spec:
-  description: Records the system resources used by each query
-  name: per_query_perf
-  query: SELECT name, interval, executions, output_size, wall_time, (user_time/executions)
-    AS avg_user_time, (system_time/executions) AS avg_system_time, average_memory
-    FROM osquery_schedule;
----
-apiVersion: v1
-kind: query
-spec:
-  description: Records avg rate of socket events since daemon started
-  name: socket_rates
-  query: SELECT COUNT(1) AS num, count(1)/s AS rate FROM socket_events, (SELECT (julianday('now')
-    - 2440587.5)*86400.0 - start_time AS s FROM osquery_info LIMIT 1);
----
-apiVersion: v1
-kind: query
-spec:
   description: Local system users.
   name: users
   query: SELECT * FROM users;
@@ -455,14 +424,6 @@ spec:
 apiVersion: v1
 kind: query
 spec:
-  description: Records avg rate of process events since daemon started
-  name: process_rates
-  query: SELECT COUNT(1) AS num, count(1)/s AS rate FROM process_events, (SELECT (julianday('now')
-    - 2440587.5)*86400.0 - start_time AS s FROM osquery_info LIMIT 1);
----
-apiVersion: v1
-kind: query
-spec:
   description: Information about the system hardware and name
   name: system_info
   query: SELECT * FROM system_info;
@@ -473,7 +434,7 @@ spec:
   description: Returns the private keys in the users ~/.ssh directory and whether
     or not they are encrypted
   name: user_ssh_keys
-  query: SELECT * FROM users JOIN user_ssh_keys USING (uid);
+  query: SELECT * FROM users CROSS JOIN user_ssh_keys USING (uid);
 ---
 apiVersion: v1
 kind: query
@@ -593,4 +554,25 @@ kind: query
 spec:
   description: A line-delimited authorized_keys table.
   name: authorized_keys
-  query: SELECT * FROM users JOIN authorized_keys USING (uid);
+  query: SELECT * FROM users CROSS JOIN authorized_keys USING (uid);
+---
+apiVersion: v1
+kind: query
+spec:
+  description: Display apt package manager sources.
+  name: apt_sources
+  query: SELECT * FROM apt_sources;
+---
+apiVersion: v1
+kind: query
+spec:
+  description: Gather information about processes that are listening on a socket.
+  name: listening_ports
+  query: SELECT pid, port, processes.path, cmdline, cwd FROM listening_ports JOIN processes USING (pid) WHERE port!=0;
+---
+apiVersion: v1
+kind: query
+spec:
+  description: Display yum package manager sources.
+  name: yum_sources
+  query: SELECT name, baseurl, enabled, gpgcheck FROM yum_sources;

--- a/Fleet/Servers/options.yaml
+++ b/Fleet/Servers/options.yaml
@@ -17,6 +17,7 @@ spec:
       configuration:
       - /etc/passwd
       - /etc/shadow
+      - /etc/ld.so.preload
       - /etc/ld.so.conf
       - /etc/ld.so.conf.d/%%
       - /etc/pam.d/%%

--- a/README.md
+++ b/README.md
@@ -59,17 +59,17 @@ environment.
 4. Logs are located in `/var/log/osquery` (Linux/MacOS) and `c:\ProgramData\osquery\logs` (Windows)
 
 ## Quickstart - Fleet
-1. Install Fleet v2.0.0 or higher on a server
-2. Configure all hosts to be enrolled to connect to the Fleet server by configuring the appropriate [flags](https://github.com/kolide/fleet/blob/master/tools/osquery/example_osquery.flags)
-2. [Configure the fleetctl utility](https://github.com/kolide/fleet/blob/master/docs/cli/setup-guide.md#fleetctl-setup) to communicate with the Fleet server
-3. Assuming you'd like to use the endpoint configs, you can use the commands below to apply them to the Fleet server:
+Install Fleet version 2.0.0 or higher
+2. [Enroll hosts to your Fleet server](https://github.com/kolide/fleet/blob/master/docs/infrastructure/adding-hosts-to-fleet.md) by configuring the appropriate [flags]
+3. [Configure the fleetctl utility](https://github.com/kolide/fleet/blob/master/docs/cli/setup-guide.md#fleetctl-setup) to communicate with your Fleet server
+4. Assuming you'd like to use the endpoint configs, you can use the commands below to apply them:
 
 ```
 git clone https://github.com/palantir/osquery-configuration.git
 fleetctl apply -f osquery-configuration/Fleet/Endpoints/options.yaml
 fleetctl apply -f osquery-configuration/Fleet/Endpoints/MacOS/osquery.yaml
 fleetctl apply -f osquery-configuration/Fleet/Endpoints/Windows/osquery.yaml
-for pack in osquery-configuration/Fleet/Endpoints/*.yaml;
+for pack in osquery-configuration/Fleet/Endpoints/packs/*.yaml;
  do fleetctl apply -f "$pack"
 done
 ```

--- a/README.md
+++ b/README.md
@@ -59,17 +59,17 @@ environment.
 4. Logs are located in `/var/log/osquery` (Linux/MacOS) and `c:\ProgramData\osquery\logs` (Windows)
 
 ## Quickstart - Fleet
-1. Install Fleet version 2.0.0 or higher 
-2. [Enroll hosts to your Fleet server](https://github.com/kolide/fleet/blob/master/docs/infrastructure/adding-hosts-to-fleet.md) by configuring the appropriate [flags](https://github.com/kolide/fleet/blob/master/tools/osquery/example_osquery.flags)
-2. [Configure the fleetctl utility](https://github.com/kolide/fleet/blob/master/docs/cli/setup-guide.md#fleetctl-setup) to communicate with your Fleet server
-3. Assuming you'd like to use the endpoint configs, you can use the commands below to apply them:
+1. Install Fleet v2.0.0 or higher on a server
+2. Configure all hosts to be enrolled to connect to the Fleet server by configuring the appropriate [flags](https://github.com/kolide/fleet/blob/master/tools/osquery/example_osquery.flags)
+2. [Configure the fleetctl utility](https://github.com/kolide/fleet/blob/master/docs/cli/setup-guide.md#fleetctl-setup) to communicate with the Fleet server
+3. Assuming you'd like to use the endpoint configs, you can use the commands below to apply them to the Fleet server:
 
 ```
 git clone https://github.com/palantir/osquery-configuration.git
 fleetctl apply -f osquery-configuration/Fleet/Endpoints/options.yaml
 fleetctl apply -f osquery-configuration/Fleet/Endpoints/MacOS/osquery.yaml
 fleetctl apply -f osquery-configuration/Fleet/Endpoints/Windows/osquery.yaml
-for pack in osquery-configuration/Fleet/Endpoints/packs/*.yaml;
+for pack in osquery-configuration/Fleet/Endpoints/*.yaml;
  do fleetctl apply -f "$pack"
 done
 ```


### PR DESCRIPTION
- Updating JOINs to CROSS JOINs when joining on the `users` table
- Fixing whitespace
- Fixing fleet intervals for Linux

**Mac Endpoint Changes**
- Updating disk_encryption to a snapshot query
- Updating disk_free_space_pct query
- Updating event_taps query
- Adding wifi_status_snapshot query

**Windows Endpoint Changes**
- Adding appcompat_shims query
- Adding bitlocker_info_snapshot query

**Linux Servers Changes**
- Adding apt_sources query
- Adding listening_ports query
- Adding yum_sources query
- Updating etc_hosts query interval
- Removing osquery_cpu_pct query
- Removing process_rates query
- Removing socket_rates query
- Removing per_query_perf query
- Add /etc/ld.so.preload for file monitoring
