### PR TITLE
Updating targets on Fleet .yaml files

### DIFF
--- a/Fleet/Endpoints/MacOS/osquery.yaml
+++ b/Fleet/Endpoints/MacOS/osquery.yaml
@@ -297,7 +297,8 @@ spec:
     query: user_ssh_keys
     removed: false
   targets:
-    labels: null
+    labels: 
+    - macOS
 ---
 apiVersion: v1
 kind: query

--- a/Fleet/Endpoints/Windows/osquery.yaml
+++ b/Fleet/Endpoints/Windows/osquery.yaml
@@ -239,7 +239,8 @@ spec:
     query: bitlocker_info_snapshot
     snapshot: true
   targets:
-    labels: null
+    labels: 
+    - MS Windows
 ---
 apiVersion: v1
 kind: query

--- a/Fleet/Endpoints/packs/performance-metrics.yaml
+++ b/Fleet/Endpoints/packs/performance-metrics.yaml
@@ -26,7 +26,9 @@ spec:
     query: backup_tool_perf
     snapshot: true
   targets:
-    labels: null
+    labels: 
+    - MS Windows
+    - macOS
 ---
 apiVersion: v1
 kind: query

--- a/Fleet/Endpoints/packs/security-tooling-checks.yaml
+++ b/Fleet/Endpoints/packs/security-tooling-checks.yaml
@@ -26,7 +26,9 @@ spec:
     platform: windows
     query: endpoint_security_tool_backend_server_registry_misconfigured
   targets:
-    labels: null
+    labels: 
+    - MS Windows
+    - macOS
 ---
 apiVersion: v1
 kind: query

--- a/Fleet/Endpoints/packs/windows-application-security.yaml
+++ b/Fleet/Endpoints/packs/windows-application-security.yaml
@@ -40,7 +40,8 @@ spec:
     platform: windows
     query: uac_settings_registry
   targets:
-    labels: null
+    labels: 
+    - MS Windows
 ---
 apiVersion: v1
 kind: query

--- a/Fleet/Endpoints/packs/windows-compliance.yaml
+++ b/Fleet/Endpoints/packs/windows-compliance.yaml
@@ -137,7 +137,8 @@ spec:
     platform: windows
     query: send_error_alert_registry
   targets:
-    labels: null
+    labels: 
+    - MS Windows
 ---
 apiVersion: v1
 kind: query

--- a/Fleet/Endpoints/packs/windows-registry-monitoring.yaml
+++ b/Fleet/Endpoints/packs/windows-registry-monitoring.yaml
@@ -185,7 +185,8 @@ spec:
     platform: windows
     query: send_error_alert_registry_exists
   targets:
-    labels: null
+    labels: 
+    - MS Windows
 ---
 apiVersion: v1
 kind: query

--- a/Fleet/Servers/Linux/osquery.yaml
+++ b/Fleet/Servers/Linux/osquery.yaml
@@ -247,7 +247,9 @@ spec:
     query: yum_sources
     snapshot: true
   targets:
-    labels: null
+    labels: 
+    - Ubuntu Linux
+    - CentOS Linux
 ---
 apiVersion: v1
 kind: query


### PR DESCRIPTION
I think an old bug with Fleet caused exported YAML to contain "null" as the target for packs. This ensures when packs are applied from the YAML that they target the correct host groups.