### PR TITLE
--disable-events=false

### DIFF
--- a/Classic/Servers/Linux/osquery.flags
+++ b/Classic/Servers/Linux/osquery.flags
@@ -2,6 +2,7 @@
 --audit_allow_sockets
 --audit_persist=true
 --disable_audit=false
+--disable_events=false
 --events_expiry=1
 --events_max=500000
 --logger_min_status=1


### PR DESCRIPTION
This flag is needed  to process events, otherwise you get "virtual_table.cpp:969] Table socket_events is event-based but events are disabled"